### PR TITLE
feat: support shank IDL

### DIFF
--- a/src/instruction-discriminator.ts
+++ b/src/instruction-discriminator.ts
@@ -1,0 +1,60 @@
+import { TypeMapper } from './type-mapper'
+import {
+  IdlInstruction,
+  IdlInstructionArg,
+  IdlTypeArray,
+  isShankIdlInstruction,
+} from './types'
+import { instructionDiscriminator } from './utils'
+
+export class InstructionDiscriminator {
+  constructor(
+    private readonly ix: IdlInstruction,
+    private readonly fieldName: string,
+    private readonly typeMapper: TypeMapper
+  ) {}
+
+  renderValue() {
+    return isShankIdlInstruction(this.ix)
+      ? JSON.stringify(this.ix.discriminant.value)
+      : JSON.stringify(Array.from(instructionDiscriminator(this.ix.name)))
+  }
+
+  // -----------------
+  // Field
+  // -----------------
+  getField(): IdlInstructionArg {
+    if (isShankIdlInstruction(this.ix)) {
+      const ty = this.ix.discriminant.type
+      this.typeMapper.assertBeetSupported(
+        ty,
+        `instruction ${this.ix.name} discriminant field`
+      )
+      return { name: this.fieldName, type: ty }
+    }
+
+    return this.anchorDiscriminatorField()
+  }
+
+  renderType(): string {
+    return isShankIdlInstruction(this.ix)
+      ? this.typeMapper.map(
+          this.ix.discriminant.type,
+          `instruction ${this.ix.name} discriminant type`
+        )
+      : this.anchorDiscriminatorType()
+  }
+
+  anchorDiscriminatorField() {
+    const ty: IdlTypeArray = { array: ['u8', 4] }
+    return { name: this.fieldName, type: ty }
+  }
+
+  anchorDiscriminatorType() {
+    const ty: IdlTypeArray = { array: ['u8', 4] }
+    return this.typeMapper.mapSerde(
+      ty,
+      `instruction ${this.ix.name} discriminant type`
+    )
+  }
+}

--- a/src/instruction-discriminator.ts
+++ b/src/instruction-discriminator.ts
@@ -2,10 +2,13 @@ import { TypeMapper } from './type-mapper'
 import {
   IdlInstruction,
   IdlInstructionArg,
-  IdlTypeArray,
   isShankIdlInstruction,
 } from './types'
-import { instructionDiscriminator } from './utils'
+import {
+  anchorDiscriminatorField,
+  anchorDiscriminatorType,
+  instructionDiscriminator,
+} from './utils'
 
 export class InstructionDiscriminator {
   constructor(
@@ -20,9 +23,6 @@ export class InstructionDiscriminator {
       : JSON.stringify(Array.from(instructionDiscriminator(this.ix.name)))
   }
 
-  // -----------------
-  // Field
-  // -----------------
   getField(): IdlInstructionArg {
     if (isShankIdlInstruction(this.ix)) {
       const ty = this.ix.discriminant.type
@@ -33,7 +33,7 @@ export class InstructionDiscriminator {
       return { name: this.fieldName, type: ty }
     }
 
-    return this.anchorDiscriminatorField()
+    return anchorDiscriminatorField(this.fieldName)
   }
 
   renderType(): string {
@@ -42,19 +42,9 @@ export class InstructionDiscriminator {
           this.ix.discriminant.type,
           `instruction ${this.ix.name} discriminant type`
         )
-      : this.anchorDiscriminatorType()
-  }
-
-  anchorDiscriminatorField() {
-    const ty: IdlTypeArray = { array: ['u8', 4] }
-    return { name: this.fieldName, type: ty }
-  }
-
-  anchorDiscriminatorType() {
-    const ty: IdlTypeArray = { array: ['u8', 4] }
-    return this.typeMapper.mapSerde(
-      ty,
-      `instruction ${this.ix.name} discriminant type`
-    )
+      : anchorDiscriminatorType(
+          this.typeMapper,
+          `instruction ${this.ix.name} discriminant type`
+        )
   }
 }

--- a/src/render-account.ts
+++ b/src/render-account.ts
@@ -284,7 +284,7 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
     if (this.hasImplicitDiscriminator) {
       discriminatorName = 'accountDiscriminator'
       discriminatorField = this.typeMapper.mapSerdeField(
-        anchorDiscriminatorField(this.accountDiscriminatorName)
+        anchorDiscriminatorField('accountDiscriminator')
       )
       discriminatorType = anchorDiscriminatorType(
         this.typeMapper,

--- a/src/render-account.ts
+++ b/src/render-account.ts
@@ -7,7 +7,11 @@ import {
   SOLANA_WEB3_PACKAGE,
   TypeMappedSerdeField,
 } from './types'
-import { accountDiscriminator } from './utils'
+import {
+  accountDiscriminator,
+  anchorDiscriminatorField,
+  anchorDiscriminatorType,
+} from './utils'
 
 function colonSeparatedTypedField(
   field: { name: string; tsType: string },
@@ -26,6 +30,7 @@ class AccountRenderer {
 
   constructor(
     private readonly account: IdlAccount,
+    private readonly hasImplicitDiscriminator: boolean,
     private readonly typeMapper: TypeMapper
   ) {
     this.upperCamelAccountName = account.name
@@ -95,6 +100,13 @@ export type ${this.accountDataArgsTypeName} = {
 
   private renderByteSizeMethods() {
     if (this.typeMapper.usedFixableSerde) {
+      const byteSizeValue = this.hasImplicitDiscriminator
+        ? `{
+      accountDiscriminator: ${this.accountDiscriminatorName},
+      ...instance,
+    }`
+        : `instance`
+
       return `
   /**
    * Returns the byteSize of a {@link Buffer} holding the serialized data of
@@ -105,10 +117,7 @@ export type ${this.accountDataArgsTypeName} = {
    */
   static byteSize(args: ${this.accountDataArgsTypeName}) {
     const instance = ${this.accountDataClassName}.fromArgs(args)
-    return ${this.dataStructName}.toFixedFromValue({
-      accountDiscriminator: ${this.accountDiscriminatorName},
-      ...instance,
-    }).byteSize
+    return ${this.dataStructName}.toFixedFromValue(${byteSizeValue}).byteSize
   }
 
   /**
@@ -170,6 +179,16 @@ export type ${this.accountDataArgsTypeName} = {
   // -----------------
   // AccountData class
   // -----------------
+  private renderAccountDiscriminatorVar() {
+    if (!this.hasImplicitDiscriminator) return ''
+
+    const accountDisc = JSON.stringify(
+      Array.from(accountDiscriminator(this.account.name))
+    )
+
+    return `const ${this.accountDiscriminatorName} = ${accountDisc}`
+  }
+
   private renderAccountDataClass(fields: { name: string; tsType: string }[]) {
     const constructorArgs = fields
       .map((f) => colonSeparatedTypedField(f, 'readonly '))
@@ -180,13 +199,18 @@ export type ${this.accountDataArgsTypeName} = {
       .join(',\n      ')
 
     const prettyFields = this.getPrettyFields().join(',\n      ')
-    const accountDisc = JSON.stringify(
-      Array.from(accountDiscriminator(this.account.name))
-    )
-
     const byteSizeMethods = this.renderByteSizeMethods()
+    const accountDiscriminatorVar = this.renderAccountDiscriminatorVar()
 
-    return `const ${this.accountDiscriminatorName} = ${accountDisc};
+    const serializeValue = this.hasImplicitDiscriminator
+      ? `{ 
+      accountDiscriminator: ${this.accountDiscriminatorName},
+      ...this
+    }`
+      : 'this'
+
+    return `
+${accountDiscriminatorVar};
 /**
  * Holds the data for the {@link ${this.upperCamelAccountName}Account} and provides de/serialization
  * functionality for that data
@@ -232,10 +256,7 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
    * @returns a tuple of the created Buffer and the offset up to which the buffer was written to store it.
    */
   serialize(): [ Buffer, number ] {
-    return ${this.dataStructName}.serialize({ 
-      accountDiscriminator: ${this.accountDiscriminatorName},
-      ...this
-    })
+    return ${this.dataStructName}.serialize(${serializeValue})
   }
 
   ${byteSizeMethods}
@@ -249,19 +270,36 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
       ${prettyFields}
     };
   }
-}`
+}`.trim()
   }
 
   // -----------------
   // Struct
   // -----------------
   private renderDataStruct(fields: TypeMappedSerdeField[]) {
+    let discriminatorName: string | undefined
+    let discriminatorField: TypeMappedSerdeField | undefined
+    let discriminatorType: string | undefined
+
+    if (this.hasImplicitDiscriminator) {
+      discriminatorName = 'accountDiscriminator'
+      discriminatorField = this.typeMapper.mapSerdeField(
+        anchorDiscriminatorField(this.accountDiscriminatorName)
+      )
+      discriminatorType = anchorDiscriminatorType(
+        this.typeMapper,
+        `account ${this.account.name} discriminant type`
+      )
+    }
+
     return renderDataStruct({
       fields,
       structVarName: this.dataStructName,
       className: this.accountDataClassName,
       argsTypename: this.accountDataArgsTypeName,
-      discriminatorName: 'accountDiscriminator',
+      discriminatorName,
+      discriminatorField,
+      discriminatorType,
       isFixable: this.typeMapper.usedFixableSerde,
     })
   }
@@ -291,9 +329,14 @@ ${dataStruct}`
 export function renderAccount(
   account: IdlAccount,
   forceFixable: ForceFixable,
-  userDefinedEnums: Set<string>
+  userDefinedEnums: Set<string>,
+  hasImplicitDiscriminator: boolean
 ) {
   const typeMapper = new TypeMapper(forceFixable, userDefinedEnums)
-  const renderer = new AccountRenderer(account, typeMapper)
+  const renderer = new AccountRenderer(
+    account,
+    hasImplicitDiscriminator,
+    typeMapper
+  )
   return renderer.render()
 }

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -7,6 +7,7 @@ import {
   SOLANA_SPL_TOKEN_EXPORT_NAME,
   TypeMappedSerdeField,
   SOLANA_WEB3_PACKAGE,
+  isIdlInstructionAccountWithDesc,
 } from './types'
 import { ForceFixable, TypeMapper } from './type-mapper'
 import { renderDataStruct } from './serdes'
@@ -124,7 +125,11 @@ ${typeMapperImports.join('\n')}`.trim()
     const web3 = SOLANA_WEB3_EXPORT_NAME
     const fields = processedKeys
       .filter((x) => x.knownPubkey == null)
-      .map((x) => `${x.name}: ${web3}.PublicKey`)
+      .map((x) =>
+        isIdlInstructionAccountWithDesc(x)
+          ? `/** ${x.desc} */\n  ${x.name}: ${web3}.PublicKey`
+          : `${x.name}: ${web3}.PublicKey`
+      )
       .join('\n  ')
 
     return `export type ${this.accountsTypename} = {

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -125,14 +125,25 @@ ${typeMapperImports.join('\n')}`.trim()
     const web3 = SOLANA_WEB3_EXPORT_NAME
     const fields = processedKeys
       .filter((x) => x.knownPubkey == null)
-      .map((x) =>
-        isIdlInstructionAccountWithDesc(x)
-          ? `/** ${x.desc} */\n  ${x.name}: ${web3}.PublicKey`
-          : `${x.name}: ${web3}.PublicKey`
-      )
+      .map((x) => `${x.name}: ${web3}.PublicKey`)
       .join('\n  ')
 
-    return `export type ${this.accountsTypename} = {
+    const propertyComments = processedKeys
+      .filter(isIdlInstructionAccountWithDesc)
+      .map((x) => ` * @property ${x.name} ${x.desc}`)
+
+    const properties =
+      propertyComments.length > 0
+        ? `\n *\n  ${propertyComments.join('\n')}`
+        : ''
+
+    const docs = `
+/**
+  * Accounts required by the _${this.ix.name}_ instruction${properties}
+  */
+`.trim()
+    return `${docs}
+export type ${this.accountsTypename} = {
   ${fields}
 }
 `

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -10,7 +10,6 @@ import {
 } from './types'
 import { ForceFixable, TypeMapper } from './type-mapper'
 import { renderDataStruct } from './serdes'
-import { instructionDiscriminator } from './utils'
 import {
   renderKnownPubkeyAccess,
   ResolvedKnownPubkey,
@@ -18,6 +17,7 @@ import {
 } from './known-pubkeys'
 import { BEET_PACKAGE } from '@metaplex-foundation/beet'
 import { renderScalarEnums } from './render-enums'
+import { InstructionDiscriminator } from './instruction-discriminator'
 
 type ProcessedAccountKey = IdlInstructionAccount & {
   knownPubkey?: ResolvedKnownPubkey
@@ -30,6 +30,7 @@ class InstructionRenderer {
   readonly accountsTypename: string
   readonly instructionDiscriminatorName: string
   readonly structArgName: string
+  private readonly instructionDiscriminator: InstructionDiscriminator
 
   constructor(
     readonly ix: IdlInstruction,
@@ -47,6 +48,12 @@ class InstructionRenderer {
     this.accountsTypename = `${this.upperCamelIxName}InstructionAccounts`
     this.instructionDiscriminatorName = `${this.camelIxName}InstructionDiscriminator`
     this.structArgName = `${ix.name}Struct`
+
+    this.instructionDiscriminator = new InstructionDiscriminator(
+      ix,
+      'instructionDiscriminator',
+      typeMapper
+    )
   }
 
   // -----------------
@@ -145,11 +152,17 @@ ${typeMapperImports.join('\n')}`.trim()
   }
 
   private renderDataStruct(args: TypeMappedSerdeField[]) {
+    const discriminatorField = this.typeMapper.mapSerdeField(
+      this.instructionDiscriminator.getField()
+    )
+    const discriminatorType = this.instructionDiscriminator.renderType()
     return renderDataStruct({
       fields: args,
+      discriminatorName: 'instructionDiscriminator',
+      discriminatorField,
+      discriminatorType,
       structVarName: this.structArgName,
       argsTypename: this.argsTypename,
-      discriminatorName: 'instructionDiscriminator',
       isFixable: this.typeMapper.usedFixableSerde,
     })
   }
@@ -166,10 +179,7 @@ ${typeMapperImports.join('\n')}`.trim()
 
     const keys = this.renderIxAccountKeys(processedKeys)
     const accountsDestructure = this.renderAccountsDestructure(processedKeys)
-    const instructionDisc = JSON.stringify(
-      Array.from(instructionDiscriminator(this.ix.name))
-    )
-
+    const instructionDisc = this.instructionDiscriminator.renderValue()
     const enums = renderScalarEnums(this.typeMapper.scalarEnumsUsed).join('\n')
 
     const web3 = SOLANA_WEB3_EXPORT_NAME

--- a/src/serdes.ts
+++ b/src/serdes.ts
@@ -126,7 +126,11 @@ export function renderDataStruct({
 
   let structType =
     fields.length === 0
-      ? `{ ${discriminatorName}: ${discriminatorType}; }`
+      ? discriminatorName == null
+        ? ''
+        : `{ ${discriminatorName}: ${discriminatorType}; }`
+      : discriminatorName == null
+      ? argsTypename
       : `${argsTypename} & {
     ${discriminatorName}: ${discriminatorType};
   }
@@ -142,7 +146,7 @@ export function renderDataStruct({
     ${structType}
 >(
   [
-    ['${discriminatorName}', ${BEET_EXPORT_NAME}.uniformFixedSizeArray(${BEET_EXPORT_NAME}.u8, 8)],
+    ${discriminatorDecl}
     ${fieldDecls}
   ],
   ${className}.fromArgs,

--- a/src/serdes.ts
+++ b/src/serdes.ts
@@ -88,7 +88,7 @@ export function assertKnownSerdePackage(
 // -----------------
 
 function renderField(field?: TypeMappedSerdeField, addSeparator = false) {
-  const sep = addSeparator ? ',\n' : ''
+  const sep = addSeparator ? ',' : ''
   return field == null ? '' : `['${field.name}', ${field.type}]${sep}`
 }
 

--- a/src/serdes.ts
+++ b/src/serdes.ts
@@ -87,6 +87,17 @@ export function assertKnownSerdePackage(
 // Rendering processed serdes to struct
 // -----------------
 
+function renderField(field?: TypeMappedSerdeField, addSeparator = false) {
+  const sep = addSeparator ? ',\n' : ''
+  return field == null ? '' : `['${field.name}', ${field.type}]${sep}`
+}
+
+function renderFields(fields?: TypeMappedSerdeField[]) {
+  return fields == null || fields.length === 0
+    ? ''
+    : fields.map((x) => renderField(x)).join(',\n    ')
+}
+
 /**
  * Renders DataStruct for Instruction Args and Account Args
  */
@@ -95,30 +106,29 @@ export function renderDataStruct({
   structVarName,
   className,
   argsTypename,
+  discriminatorField,
   discriminatorName,
+  discriminatorType,
   isFixable,
 }: {
+  discriminatorName?: string
+  discriminatorField?: TypeMappedSerdeField
+  discriminatorType?: string
   fields: TypeMappedSerdeField[]
   structVarName: string
   className?: string
   argsTypename: string
-  discriminatorName?: string
   isFixable: boolean
 }) {
-  const fieldDecls =
-    fields.length === 0
-      ? ''
-      : fields
-          .map((f) => {
-            return `['${f.name}', ${f.type}]`
-          })
-          .join(',\n    ')
+  const fieldDecls = renderFields(fields)
+  const discriminatorDecl = renderField(discriminatorField, true)
+  discriminatorType = discriminatorType ?? 'number[]'
 
   let structType =
     fields.length === 0
-      ? `{ ${discriminatorName}: number[]; }`
+      ? `{ ${discriminatorName}: ${discriminatorType}; }`
       : `${argsTypename} & {
-    ${discriminatorName}: number[];
+    ${discriminatorName}: ${discriminatorType};
   }
 `
 
@@ -147,7 +157,7 @@ export function renderDataStruct({
     // -----------------
     return `const ${structVarName} = new ${BEET_EXPORT_NAME}.${beetArgsStructType}<${structType}>(
   [
-    ['${discriminatorName}', ${BEET_EXPORT_NAME}.uniformFixedSizeArray(${BEET_EXPORT_NAME}.u8, 8)],
+    ${discriminatorDecl}
     ${fieldDecls}
   ],
   '${argsTypename}'

--- a/src/solita.ts
+++ b/src/solita.ts
@@ -9,6 +9,7 @@ import {
   isIdlDefinedType,
   isIdlTypeDefined,
   isIdlTypeEnum,
+  isShankIdl,
 } from './types'
 import { logDebug, logInfo, logTrace, prepareTargetDir } from './utils'
 import { format, Options } from 'prettier'
@@ -35,6 +36,7 @@ const DEFAULT_FORMAT_OPTS: Options = {
 export class Solita {
   private readonly formatCode: boolean
   private readonly formatOpts: Options
+  private readonly accountsHaveImplicitDiscriminator: boolean
   constructor(
     private readonly idl: Idl,
     {
@@ -44,6 +46,7 @@ export class Solita {
   ) {
     this.formatCode = formatCode
     this.formatOpts = { ...DEFAULT_FORMAT_OPTS, ...formatOpts }
+    this.accountsHaveImplicitDiscriminator = !isShankIdl(idl)
   }
 
   renderCode() {
@@ -118,7 +121,12 @@ export class Solita {
     for (const account of this.idl.accounts ?? []) {
       logDebug(`Rendering account ${account.name}`)
       logTrace('type: %O', account.type)
-      let code = renderAccount(account, forceFixable, userDefinedEnums)
+      let code = renderAccount(
+        account,
+        forceFixable,
+        userDefinedEnums,
+        this.accountsHaveImplicitDiscriminator
+      )
       if (this.formatCode) {
         try {
           code = format(code, this.formatOpts)

--- a/src/type-mapper.ts
+++ b/src/type-mapper.ts
@@ -283,13 +283,17 @@ export class TypeMapper {
     throw new Error(`Type ${ty} required for ${name} is not yet supported`)
   }
 
+  mapSerdeField = (
+    field: IdlField | IdlInstructionArg
+  ): TypeMappedSerdeField => {
+    const ty = this.mapSerde(field.type, field.name)
+    return { name: field.name, type: ty }
+  }
+
   mapSerdeFields(
     fields: (IdlField | IdlInstructionArg)[]
   ): TypeMappedSerdeField[] {
-    return fields.map((f) => {
-      const ty = this.mapSerde(f.type, f.name)
-      return { name: f.name, type: ty }
-    })
+    return fields.map(this.mapSerdeField)
   }
 
   // -----------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,25 @@ export type Idl = {
 }
 
 // -----------------
+// Shank Idl Extensions
+// -----------------
+export type ShankIdl = Idl & {
+  instructions: ShankIdlInstruction[]
+  metadata: ShankMetadata
+}
+export type ShankIdlInstruction = IdlInstruction & {
+  accounts: ShankIdlInstructionAccount[]
+  discriminant: {
+    type: IdlType
+    value: number
+  }
+}
+export type ShankIdlInstructionAccount = IdlInstructionAccount & {
+  desc: string
+}
+export type ShankMetadata = Idl['metadata'] & { origin: 'shank' }
+
+// -----------------
 // De/Serializers + Extensions
 // -----------------
 export type PrimaryTypeMap = Record<
@@ -160,6 +179,16 @@ export function isIdlDefinedType(
   ty: IdlType | IdlDefinedType
 ): ty is IdlDefinedType {
   return (ty as IdlDefinedType).fields != null
+}
+
+export function isShankIdl(ty: Idl): ty is ShankIdl {
+  return (ty as ShankIdl).metadata?.origin === 'shank'
+}
+
+export function isShankIdlInstruction(
+  ty: IdlInstruction
+): ty is ShankIdlInstruction {
+  return typeof (ty as ShankIdlInstruction).discriminant === 'object'
 }
 
 // -----------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,13 +119,13 @@ export type ShankIdl = Idl & {
   metadata: ShankMetadata
 }
 export type ShankIdlInstruction = IdlInstruction & {
-  accounts: ShankIdlInstructionAccount[]
+  accounts: IdlInstructionAccountWithDesc[]
   discriminant: {
     type: IdlType
     value: number
   }
 }
-export type ShankIdlInstructionAccount = IdlInstructionAccount & {
+export type IdlInstructionAccountWithDesc = IdlInstructionAccount & {
   desc: string
 }
 export type ShankMetadata = Idl['metadata'] & { origin: 'shank' }
@@ -189,6 +189,12 @@ export function isShankIdlInstruction(
   ty: IdlInstruction
 ): ty is ShankIdlInstruction {
   return typeof (ty as ShankIdlInstruction).discriminant === 'object'
+}
+
+export function isIdlInstructionAccountWithDesc(
+  ty: IdlInstructionAccount
+): ty is IdlInstructionAccountWithDesc {
+  return typeof (ty as IdlInstructionAccountWithDesc).desc === 'string'
 }
 
 // -----------------

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,7 @@ function sighash(nameSpace: string, ixName: string): Buffer {
 }
 
 export function anchorDiscriminatorField(name: string) {
-  const ty: IdlTypeArray = { array: ['u8', 4] }
+  const ty: IdlTypeArray = { array: ['u8', 8] }
   return { name, type: ty }
 }
 
@@ -111,6 +111,6 @@ export function anchorDiscriminatorType(
   typeMapper: TypeMapper,
   context: string
 ) {
-  const ty: IdlTypeArray = { array: ['u8', 4] }
+  const ty: IdlTypeArray = { array: ['u8', 8] }
   return typeMapper.map(ty, context)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,8 @@ import path from 'path'
 import { sha256 } from 'js-sha256'
 import camelcase from 'camelcase'
 import { snakeCase } from 'snake-case'
+import { IdlTypeArray } from './types'
+import { TypeMapper } from './type-mapper'
 
 export const logError = debug('solita:error')
 export const logInfo = debug('solita:info')
@@ -98,4 +100,17 @@ function sighash(nameSpace: string, ixName: string): Buffer {
   let name = snakeCase(ixName)
   let preimage = `${nameSpace}:${name}`
   return Buffer.from(sha256.digest(preimage)).slice(0, 8)
+}
+
+export function anchorDiscriminatorField(name: string) {
+  const ty: IdlTypeArray = { array: ['u8', 4] }
+  return { name, type: ty }
+}
+
+export function anchorDiscriminatorType(
+  typeMapper: TypeMapper,
+  context: string
+) {
+  const ty: IdlTypeArray = { array: ['u8', 4] }
+  return typeMapper.map(ty, context)
 }

--- a/test/anchor-examples/basic-0/.ammanrc.js
+++ b/test/anchor-examples/basic-0/.ammanrc.js
@@ -9,4 +9,4 @@ const validator = {
     },
   ],
 }
-module.exports = { validator }
+module.exports = { validator, commitment: 'singleGossip' }

--- a/test/anchor-examples/basic-1/.ammanrc.js
+++ b/test/anchor-examples/basic-1/.ammanrc.js
@@ -9,4 +9,4 @@ const validator = {
     },
   ],
 }
-module.exports = { validator }
+module.exports = { validator, commitment: 'singleGossip' }

--- a/test/anchor-examples/basic-2/.ammanrc.js
+++ b/test/anchor-examples/basic-2/.ammanrc.js
@@ -9,4 +9,4 @@ const validator = {
     },
   ],
 }
-module.exports = { validator }
+module.exports = { validator, commitment: 'singleGossip' }

--- a/test/anchor-examples/basic-3/.ammanrc.js
+++ b/test/anchor-examples/basic-3/.ammanrc.js
@@ -14,4 +14,4 @@ const validator = {
     },
   ],
 }
-module.exports = { validator }
+module.exports = { validator, commitment: 'singleGossip' }

--- a/test/anchor-examples/basic-4/.ammanrc.js
+++ b/test/anchor-examples/basic-4/.ammanrc.js
@@ -9,4 +9,4 @@ const validator = {
     },
   ],
 }
-module.exports = { validator }
+module.exports = { validator, commitment: 'singleGossip' }

--- a/test/integration/fixtures/shank_tictactoe.json
+++ b/test/integration/fixtures/shank_tictactoe.json
@@ -1,0 +1,176 @@
+{
+  "version": "0.1.0",
+  "name": "tictactoe",
+  "instructions": [
+    {
+      "name": "InitializeDashboard",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority initializing the dashboard"
+        },
+        {
+          "name": "dashboard",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "The account to store dashboard data"
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u32",
+        "value": 0
+      }
+    },
+    {
+      "name": "InitializeGame",
+      "accounts": [
+        {
+          "name": "playerX",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "dashboard",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "game",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u32",
+        "value": 1
+      }
+    },
+    {
+      "name": "PlayerJoin",
+      "accounts": [
+        {
+          "name": "playerO",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "game",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u32",
+        "value": 2
+      }
+    },
+    {
+      "name": "PlayerMove",
+      "accounts": [
+        {
+          "name": "player",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "game",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "playerMove",
+          "type": {
+            "defined": "PlayerMove"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u32",
+        "value": 3
+      }
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Dashboard",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "gameCount",
+            "type": "u64"
+          },
+          {
+            "name": "latestGame",
+            "type": "publicKey"
+          },
+          {
+            "name": "address",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Game",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "keepAlive",
+            "type": {
+              "array": ["u64", 2]
+            }
+          },
+          {
+            "name": "playerX",
+            "type": "publicKey"
+          },
+          {
+            "name": "playerO",
+            "type": "publicKey"
+          },
+          {
+            "name": "gameState",
+            "type": "u8"
+          },
+          {
+            "name": "board",
+            "type": {
+              "array": ["u8", 9]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "PlayerMove",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "xOrO",
+            "type": "u8"
+          },
+          {
+            "name": "field",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank",
+    "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+  }
+}

--- a/test/integration/shank-tictactoe.ts
+++ b/test/integration/shank-tictactoe.ts
@@ -1,0 +1,15 @@
+import { Idl, Solita } from '../../src/solita'
+import test from 'tape'
+import path from 'path'
+import { verifySyntacticCorrectnessForGeneratedDir } from '../utils/verify-code'
+import json from './fixtures/shank_tictactoe.json'
+
+const outputDir = path.join(__dirname, 'output', 'shank-tictactoe')
+const generatedSDKDir = path.join(outputDir, 'generated')
+
+test('renders type correct SDK for shank_tictactoe', async (t) => {
+  const idl = json as Idl
+  const gen = new Solita(idl, { formatCode: true })
+  await gen.renderAndWriteTo(generatedSDKDir)
+  await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
+})

--- a/test/render-accounts.ts
+++ b/test/render-accounts.ts
@@ -27,15 +27,17 @@ async function checkRenderedAccount(
   } = { logImports: DIAGNOSTIC_ON, logCode: DIAGNOSTIC_ON }
 ) {
   const { userDefinedEnums = new Set() } = opts
-  const ts = renderAccount(account, FORCE_FIXABLE_NEVER, userDefinedEnums)
-  verifySyntacticCorrectness(t, ts)
+  const ts = renderAccount(account, FORCE_FIXABLE_NEVER, userDefinedEnums, true)
 
-  const analyzed = await analyzeCode(ts)
   if (opts.logCode) {
     console.log(
       `--------- <TypeScript> --------\n${ts}\n--------- </TypeScript> --------`
     )
   }
+
+  verifySyntacticCorrectness(t, ts)
+
+  const analyzed = await analyzeCode(ts)
   verifyImports(t, analyzed, imports, { logImports: opts.logImports })
 }
 


### PR DESCRIPTION
## Discriminators

Anchor implicitly works with instruction and account discriminators that are derived from their
name. This is not the case for plain contracts and thus for the ones whose IDL was extracted
via _shank_ we cannot assume that.

Instead shank provides discriminator information for each instruction (either the variant slot
or a value specified explicitly). For accounts no discriminator is assumed, but can be provided
via a `key` property which then works like any other account field.

Solita assumes no _magic_ discriminators for IDL whose `metadata.origin === 'shank'`.
It now generates correct code for these cases without breaking compatibility with _anchor_ IDL.

## Account Description

Additionally instruction accounts extracted via _shank_ can have a `desc` property which is
included as a comment.

## Chores

`.ammanrc`s were updated to speed up anchor integration tests.


