### PR TITLE
chore: fixes and improvements while integrating

### DIFF
--- a/src/known-pubkeys.ts
+++ b/src/known-pubkeys.ts
@@ -51,6 +51,10 @@ export type ResolvedKnownPubkey = {
   packExportName: PubkeysPackageExportName
 }
 
+export function isKnownPubkey(id: string) {
+  return knownPubkeysMap.has(id)
+}
+
 export function resolveKnownPubkey(id: string): ResolvedKnownPubkey | null {
   const item = knownPubkeysMap.get(id)
   if (item == null) return null

--- a/src/render-account.ts
+++ b/src/render-account.ts
@@ -26,7 +26,7 @@ class AccountRenderer {
   readonly accountDataClassName: string
   readonly accountDataArgsTypeName: string
   readonly accountDiscriminatorName: string
-  readonly dataStructName: string
+  readonly beetName: string
 
   constructor(
     private readonly account: IdlAccount,
@@ -43,10 +43,10 @@ class AccountRenderer {
       .toLowerCase()
       .concat(account.name.slice(1))
 
-    this.accountDataClassName = `${this.upperCamelAccountName}AccountData`
+    this.accountDataClassName = this.upperCamelAccountName
     this.accountDataArgsTypeName = `${this.accountDataClassName}Args`
-    this.dataStructName = `${this.camelAccountName}AccountDataStruct`
-    this.accountDiscriminatorName = `${this.camelAccountName}AccountDiscriminator`
+    this.beetName = `${this.camelAccountName}Beet`
+    this.accountDiscriminatorName = `${this.camelAccountName}Discriminator`
   }
 
   private serdeProcess() {
@@ -117,7 +117,7 @@ export type ${this.accountDataArgsTypeName} = {
    */
   static byteSize(args: ${this.accountDataArgsTypeName}) {
     const instance = ${this.accountDataClassName}.fromArgs(args)
-    return ${this.dataStructName}.toFixedFromValue(${byteSizeValue}).byteSize
+    return ${this.beetName}.toFixedFromValue(${byteSizeValue}).byteSize
   }
 
   /**
@@ -146,7 +146,7 @@ export type ${this.accountDataArgsTypeName} = {
    * {@link ${this.accountDataClassName}}
    */
   static get byteSize() {
-    return ${this.dataStructName}.byteSize;
+    return ${this.beetName}.byteSize;
   }
 
   /**
@@ -212,7 +212,7 @@ export type ${this.accountDataArgsTypeName} = {
     return `
 ${accountDiscriminatorVar};
 /**
- * Holds the data for the {@link ${this.upperCamelAccountName}Account} and provides de/serialization
+ * Holds the data for the {@link ${this.upperCamelAccountName}} Account and provides de/serialization
  * functionality for that data
  */
 export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeName} {
@@ -248,7 +248,7 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
     buf: Buffer,
     offset = 0
   ): [ ${this.accountDataClassName}, number ]{
-    return ${this.dataStructName}.deserialize(buf, offset);
+    return ${this.beetName}.deserialize(buf, offset);
   }
 
   /**
@@ -256,7 +256,7 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
    * @returns a tuple of the created Buffer and the offset up to which the buffer was written to store it.
    */
   serialize(): [ Buffer, number ] {
-    return ${this.dataStructName}.serialize(${serializeValue})
+    return ${this.beetName}.serialize(${serializeValue})
   }
 
   ${byteSizeMethods}
@@ -276,7 +276,7 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
   // -----------------
   // Struct
   // -----------------
-  private renderDataStruct(fields: TypeMappedSerdeField[]) {
+  private renderBeet(fields: TypeMappedSerdeField[]) {
     let discriminatorName: string | undefined
     let discriminatorField: TypeMappedSerdeField | undefined
     let discriminatorType: string | undefined
@@ -294,7 +294,7 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
 
     return renderDataStruct({
       fields,
-      structVarName: this.dataStructName,
+      structVarName: this.beetName,
       className: this.accountDataClassName,
       argsTypename: this.accountDataArgsTypeName,
       discriminatorName,
@@ -313,7 +313,7 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
     const imports = this.renderImports()
     const accountDataArgsType = this.renderAccountDataArgsType(typedFields)
     const accountDataClass = this.renderAccountDataClass(typedFields)
-    const dataStruct = this.renderDataStruct(beetFields)
+    const beetDecl = this.renderBeet(beetFields)
     return `${imports}
 
 ${enums}
@@ -322,7 +322,7 @@ ${accountDataArgsType}
 
 ${accountDataClass}
 
-${dataStruct}`
+${beetDecl}`
   }
 }
 

--- a/src/render-account.ts
+++ b/src/render-account.ts
@@ -329,10 +329,9 @@ ${dataStruct}`
 export function renderAccount(
   account: IdlAccount,
   forceFixable: ForceFixable,
-  userDefinedEnums: Set<string>,
   hasImplicitDiscriminator: boolean
 ) {
-  const typeMapper = new TypeMapper(forceFixable, userDefinedEnums)
+  const typeMapper = new TypeMapper(forceFixable)
   const renderer = new AccountRenderer(
     account,
     hasImplicitDiscriminator,

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -12,6 +12,7 @@ import {
 import { ForceFixable, TypeMapper } from './type-mapper'
 import { renderDataStruct } from './serdes'
 import {
+  isKnownPubkey,
   renderKnownPubkeyAccess,
   ResolvedKnownPubkey,
   resolveKnownPubkey,
@@ -130,6 +131,8 @@ ${typeMapperImports.join('\n')}`.trim()
 
     const propertyComments = processedKeys
       .filter(isIdlInstructionAccountWithDesc)
+      // known pubkeys are not provided by the user and thus aren't part of the type
+      .filter((x) => !isKnownPubkey(x.name))
       .map((x) => {
         const attrs = []
         if (x.isMut) attrs.push('writable')

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -250,10 +250,9 @@ export function create${this.upperCamelIxName}Instruction(
 export function renderInstruction(
   ix: IdlInstruction,
   programId: string,
-  forceFixable: ForceFixable,
-  userDefinedEnums: Set<string>
+  forceFixable: ForceFixable
 ) {
-  const typeMapper = new TypeMapper(forceFixable, userDefinedEnums)
+  const typeMapper = new TypeMapper(forceFixable)
   const renderer = new InstructionRenderer(ix, programId, typeMapper)
   return renderer.render()
 }

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -130,7 +130,13 @@ ${typeMapperImports.join('\n')}`.trim()
 
     const propertyComments = processedKeys
       .filter(isIdlInstructionAccountWithDesc)
-      .map((x) => ` * @property ${x.name} ${x.desc}`)
+      .map((x) => {
+        const attrs = []
+        if (x.isMut) attrs.push('writable')
+        if (x.isSigner) attrs.push('signer')
+
+        return ` * @property [${attrs.join(', ')}] ${x.name} ${x.desc}`
+      })
 
     const properties =
       propertyComments.length > 0

--- a/src/serdes.ts
+++ b/src/serdes.ts
@@ -174,12 +174,12 @@ export function renderDataStruct({
  */
 export function renderTypeDataStruct({
   fields,
-  structVarName,
+  beetVarName,
   typeName,
   isFixable,
 }: {
   fields: TypeMappedSerdeField[]
-  structVarName: string
+  beetVarName: string
   typeName: string
   isFixable: boolean
 }) {
@@ -200,7 +200,7 @@ export function renderTypeDataStruct({
   // -----------------
   // Beet Args Struct (Instruction)
   // -----------------
-  return `const ${structVarName} = new ${BEET_EXPORT_NAME}.${beetArgsStructType}<${typeName}>(
+  return `const ${beetVarName} = new ${BEET_EXPORT_NAME}.${beetArgsStructType}<${typeName}>(
   [
     ${fieldDecls}
   ],

--- a/src/serdes.ts
+++ b/src/serdes.ts
@@ -141,7 +141,7 @@ export function renderDataStruct({
   // -----------------
   if (className != null) {
     const beetStructType = isFixable ? 'FixableBeetStruct' : 'BeetStruct'
-    return `const ${structVarName} = new ${BEET_EXPORT_NAME}.${beetStructType}<
+    return `export const ${structVarName} = new ${BEET_EXPORT_NAME}.${beetStructType}<
     ${className},
     ${structType}
 >(

--- a/src/solita.ts
+++ b/src/solita.ts
@@ -52,7 +52,6 @@ export class Solita {
   renderCode() {
     const programId = this.idl.metadata.address
     const fixableTypes: Set<string> = new Set()
-    let userDefinedEnums: Set<string> = new Set()
 
     function forceFixable(ty: IdlType) {
       if (isIdlTypeDefined(ty) && fixableTypes.has(ty.defined)) {
@@ -77,8 +76,7 @@ export class Solita {
             logTrace('variants: %O', ty.type.variants)
           }
         }
-        let { code, isFixable, userDefinedEnums: enums } = renderType(ty)
-        userDefinedEnums = enums
+        let { code, isFixable } = renderType(ty)
 
         if (isFixable) {
           fixableTypes.add(ty.name)
@@ -100,12 +98,7 @@ export class Solita {
       logDebug(`Rendering instruction ${ix.name}`)
       logTrace('args: %O', ix.args)
       logTrace('accounts: %O', ix.accounts)
-      let code = renderInstruction(
-        ix,
-        programId,
-        forceFixable,
-        userDefinedEnums
-      )
+      let code = renderInstruction(ix, programId, forceFixable)
       if (this.formatCode) {
         try {
           code = format(code, this.formatOpts)
@@ -124,7 +117,6 @@ export class Solita {
       let code = renderAccount(
         account,
         forceFixable,
-        userDefinedEnums,
         this.accountsHaveImplicitDiscriminator
       )
       if (this.formatCode) {

--- a/src/type-mapper.ts
+++ b/src/type-mapper.ts
@@ -34,10 +34,7 @@ import {
   SerdePackage,
   serdePackageExportName,
 } from './serdes'
-import {
-  enumVarNameFromTypeName,
-  structVarNameFromTypeName,
-} from './render-type'
+import { beetVarNameFromTypeName } from './render-type'
 
 export function resolveSerdeAlias(ty: string) {
   switch (ty) {
@@ -58,7 +55,6 @@ export class TypeMapper {
   usedFixableSerde: boolean = false
   constructor(
     private readonly forceFixable: ForceFixable = FORCE_FIXABLE_NEVER,
-    private readonly userDefinedEnums: Set<string> = new Set(),
     private readonly primaryTypeMap: PrimaryTypeMap = TypeMapper.defaultPrimaryTypeMap
   ) {}
 
@@ -237,9 +233,7 @@ export class TypeMapper {
     const userDefinedPackage = LOCAL_TYPES_PACKAGE
     this.serdePackagesUsed.add(userDefinedPackage)
     const exp = serdePackageExportName(userDefinedPackage)
-    const varName = this.userDefinedEnums.has(ty.defined)
-      ? enumVarNameFromTypeName(ty.defined)
-      : structVarNameFromTypeName(ty.defined)
+    const varName = beetVarNameFromTypeName(ty.defined)
     return `${exp}.${varName}`
   }
 

--- a/test/anchor-examples/basic-1/test/initialize-and-update.ts
+++ b/test/anchor-examples/basic-1/test/initialize-and-update.ts
@@ -3,7 +3,7 @@ import { Connection, Transaction } from '@solana/web3.js'
 import {
   createInitializeInstruction,
   createUpdateInstruction,
-  MyAccountAccountData,
+  MyAccount,
 } from '../src/'
 import {
   AddressLabels,
@@ -68,7 +68,7 @@ test('initialize', async (t) => {
   })
 
   const accountInfo = await connection.getAccountInfo(myAccount)
-  const [account] = MyAccountAccountData.fromAccountInfo(accountInfo!)
+  const [account] = MyAccount.fromAccountInfo(accountInfo!)
 
   t.equal(
     account.data.toString(),
@@ -90,7 +90,7 @@ test('update', async (t) => {
   })
 
   const accountInfo = await connection.getAccountInfo(myAccount)
-  const [account] = MyAccountAccountData.fromAccountInfo(accountInfo!)
+  const [account] = MyAccount.fromAccountInfo(accountInfo!)
 
   t.equal(account.data.toString(), '2', 'updates account with provided data')
 })

--- a/test/anchor-examples/basic-2/test/create-and-increment.ts
+++ b/test/anchor-examples/basic-2/test/create-and-increment.ts
@@ -1,7 +1,7 @@
 import test from 'tape'
 import { Connection, Transaction } from '@solana/web3.js'
 import {
-  CounterAccountData,
+  Counter,
   createCreateInstruction,
   createIncrementInstruction,
 } from '../src/'
@@ -72,7 +72,7 @@ test('create', async (t) => {
   })
 
   const accountInfo = await connection.getAccountInfo(counter)
-  const [account] = CounterAccountData.fromAccountInfo(accountInfo!)
+  const [account] = Counter.fromAccountInfo(accountInfo!)
 
   t.ok(account.authority.equals(payer), 'payer is authority')
   t.equal(account.count.toString(), '0', 'initializes count to 0')
@@ -90,7 +90,7 @@ test('increment', async (t) => {
   })
 
   const accountInfo = await connection.getAccountInfo(counter)
-  const [account] = CounterAccountData.fromAccountInfo(accountInfo!)
+  const [account] = Counter.fromAccountInfo(accountInfo!)
 
   t.ok(account.authority.equals(payer), 'payer is authority')
   t.equal(account.count.toString(), '1', 'increments count to 1')

--- a/test/anchor-examples/basic-3/test/create-and-pull.ts
+++ b/test/anchor-examples/basic-3/test/create-and-pull.ts
@@ -11,7 +11,7 @@ import {
 import {
   createInitializeInstruction,
   createPullStringsInstruction,
-  DataAccountData,
+  Data,
 } from '../src/'
 
 const puppetIdl = require('../idl/puppet.json')
@@ -71,7 +71,7 @@ test('create', async (t) => {
   })
 
   const accountInfo = await connection.getAccountInfo(puppet)
-  const [account] = DataAccountData.fromAccountInfo(accountInfo!)
+  const [account] = Data.fromAccountInfo(accountInfo!)
 
   t.equal(account.data.toString(), '0', 'initializes data to 0')
 })
@@ -91,7 +91,7 @@ test('pull strings', async (t) => {
   })
 
   const accountInfo = await connection.getAccountInfo(puppet)
-  const [account] = DataAccountData.fromAccountInfo(accountInfo!)
+  const [account] = Data.fromAccountInfo(accountInfo!)
 
   t.equal(account.data.toString(), '111', 'updates puppet account data')
 })

--- a/test/anchor-examples/basic-4/test/emitting-errors.ts
+++ b/test/anchor-examples/basic-4/test/emitting-errors.ts
@@ -1,7 +1,7 @@
 import test from 'tape'
 import { Connection, Transaction } from '@solana/web3.js'
 import {
-  CounterAccountData,
+  Counter,
   createCreateInstruction,
   createDecrementInstruction,
   createIncrementInstruction,
@@ -94,7 +94,7 @@ test('increment two times', async (t) => {
     })
 
     const accountInfo = await connection.getAccountInfo(counter)
-    const [account] = CounterAccountData.fromAccountInfo(accountInfo!)
+    const [account] = Counter.fromAccountInfo(accountInfo!)
 
     t.ok(account.authority.equals(payer), 'payer is authority')
     t.equal(account.count.toString(), '1', 'increments count to 1')
@@ -118,7 +118,7 @@ test('increment two times', async (t) => {
       t.match(resolvedError.message, /cannot increment more/i, 'err message')
     }
     const accountInfo = await connection.getAccountInfo(counter)
-    const [account] = CounterAccountData.fromAccountInfo(accountInfo!)
+    const [account] = Counter.fromAccountInfo(accountInfo!)
 
     t.ok(account.authority.equals(payer), 'payer is still authority')
     t.equal(account.count.toString(), '1', 'keeps count at 1')

--- a/test/integration/fixtures/shank_token_vault.json
+++ b/test/integration/fixtures/shank_token_vault.json
@@ -1,0 +1,842 @@
+{
+  "version": "0.1.0",
+  "name": "mpl_token_vault",
+  "instructions": [
+    {
+      "name": "InitVault",
+      "accounts": [
+        {
+          "name": "fractionMint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized fractional share mint with 0 tokens in supply, authority on mint must be pda of program with seed [prefix, programid]"
+        },
+        {
+          "name": "redeemTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized redeem treasury token account with 0 tokens in supply, owner of account must be pda of program like above"
+        },
+        {
+          "name": "fractionTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized fraction treasury token account with 0 tokens in supply, owner of account must be pda of program like above"
+        },
+        {
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Uninitialized vault account"
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Authority on the vault"
+        },
+        {
+          "name": "pricingLookupAddress",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Pricing Lookup Address"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Rent sysvar"
+        }
+      ],
+      "args": [
+        {
+          "name": "initVaultArgs",
+          "type": {
+            "defined": "InitVaultArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    },
+    {
+      "name": "AddTokenToInactiveVault",
+      "accounts": [
+        {
+          "name": "safetyDepositAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Uninitialized safety deposit box account address (will be created and allocated by this endpoint) Address should be pda with seed of [PREFIX, vault_address, token_mint_address]"
+        },
+        {
+          "name": "tokenAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized Token account"
+        },
+        {
+          "name": "store",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized Token store account with authority of this program, this will get set on the safety deposit box"
+        },
+        {
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized inactive fractionalized token vault"
+        },
+        {
+          "name": "vaultAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority on the vault"
+        },
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Payer"
+        },
+        {
+          "name": "transferAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Transfer Authority to move desired token amount from token account to safety deposit"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Rent sysvar"
+        },
+        {
+          "name": "systemAccount",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "System account sysvar"
+        }
+      ],
+      "args": [
+        {
+          "name": "amountArgs",
+          "type": {
+            "defined": "AmountArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 1
+      }
+    },
+    {
+      "name": "ActivateVault",
+      "accounts": [
+        {
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized inactivated fractionalized token vault"
+        },
+        {
+          "name": "fractionMint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction mint"
+        },
+        {
+          "name": "fractionTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction treasury"
+        },
+        {
+          "name": "fractionalMintAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Fraction mint authority for the program - seed of [PREFIX, program_id]"
+        },
+        {
+          "name": "vaultAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority on the vault"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        }
+      ],
+      "args": [
+        {
+          "name": "numberOfShareArgs",
+          "type": {
+            "defined": "NumberOfShareArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 2
+      }
+    },
+    {
+      "name": "CombineVault",
+      "accounts": [
+        {
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized activated token vault"
+        },
+        {
+          "name": "yourOutstandingShares",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account containing your portion of the outstanding fraction shares"
+        },
+        {
+          "name": "yourPayment",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Token account of the redeem_treasury mint type that you will pay with"
+        },
+        {
+          "name": "fractionMint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction mint"
+        },
+        {
+          "name": "fractionTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction treasury account"
+        },
+        {
+          "name": "redeemTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Redeem treasury account"
+        },
+        {
+          "name": "newVaultAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "New authority on the vault going forward - can be same authority if you want"
+        },
+        {
+          "name": "vaultAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority on the vault"
+        },
+        {
+          "name": "transferAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Transfer authority for the token account and outstanding fractional shares account you're transferring from"
+        },
+        {
+          "name": "fractionBurnAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "PDA-based Burn authority for the fraction treasury account containing the uncirculated shares seed [PREFIX, program_id]"
+        },
+        {
+          "name": "externalPricing",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "External pricing lookup address"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 3
+      }
+    },
+    {
+      "name": "RedeemShares",
+      "accounts": [
+        {
+          "name": "outstandingShares",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized Token account containing your fractional shares"
+        },
+        {
+          "name": "destination",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized Destination token account where you wish your proceeds to arrive"
+        },
+        {
+          "name": "fractionMint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction mint"
+        },
+        {
+          "name": "redeemTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Redeem treasury account"
+        },
+        {
+          "name": "transferAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "PDA-based Transfer authority for the transfer of proceeds from redeem treasury to destination seed [PREFIX, program_id]"
+        },
+        {
+          "name": "burnAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Burn authority for the burning of your shares"
+        },
+        {
+          "name": "vault",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Combined token vault"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Rent sysvar"
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 4
+      }
+    },
+    {
+      "name": "WithdrawTokenFromSafetyDepositBox",
+      "accounts": [
+        {
+          "name": "destination",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized Destination account for the tokens being withdrawn"
+        },
+        {
+          "name": "safetyDeposit",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "The safety deposit box account key for the tokens"
+        },
+        {
+          "name": "store",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "The store key on the safety deposit box account"
+        },
+        {
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "The initialized combined token vault"
+        },
+        {
+          "name": "fractionMint",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Fraction mint"
+        },
+        {
+          "name": "vaultAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority of vault"
+        },
+        {
+          "name": "transferAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "PDA-based Transfer authority to move the tokens from the store to the destination seed [PREFIX, program_id]"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Rent sysvar"
+        }
+      ],
+      "args": [
+        {
+          "name": "amountArgs",
+          "type": {
+            "defined": "AmountArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 5
+      }
+    },
+    {
+      "name": "MintFractionalShares",
+      "accounts": [
+        {
+          "name": "fractionTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction treasury"
+        },
+        {
+          "name": "fractionMint",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction mint"
+        },
+        {
+          "name": "vault",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "The initialized active token vault"
+        },
+        {
+          "name": "mintAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "PDA-based Mint authority to mint tokens to treasury[PREFIX, program_id]"
+        },
+        {
+          "name": "vaultAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority of vault"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        }
+      ],
+      "args": [
+        {
+          "name": "numberOfShareArgs",
+          "type": {
+            "defined": "NumberOfShareArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 6
+      }
+    },
+    {
+      "name": "WithdrawSharesFromTreasury",
+      "accounts": [
+        {
+          "name": "destination",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized Destination account for the shares being withdrawn"
+        },
+        {
+          "name": "fractionTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction treasury"
+        },
+        {
+          "name": "vault",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "The initialized active token vault"
+        },
+        {
+          "name": "transferAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "PDA-based Transfer authority to move tokens from treasury to your destination[PREFIX, program_id]"
+        },
+        {
+          "name": "vaultAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority of vault"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Rent sysvar"
+        }
+      ],
+      "args": [
+        {
+          "name": "numberOfShareArgs",
+          "type": {
+            "defined": "NumberOfShareArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 7
+      }
+    },
+    {
+      "name": "AddSharesToTreasury",
+      "accounts": [
+        {
+          "name": "source",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Initialized account from which shares will be withdrawn"
+        },
+        {
+          "name": "fractionTreasury",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Fraction treasury"
+        },
+        {
+          "name": "vault",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "The initialized active token vault"
+        },
+        {
+          "name": "transferAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Transfer authority to move tokens from your account to treasury"
+        },
+        {
+          "name": "vaultAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Authority of vault"
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "Token program"
+        }
+      ],
+      "args": [
+        {
+          "name": "numberOfShareArgs",
+          "type": {
+            "defined": "NumberOfShareArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 8
+      }
+    },
+    {
+      "name": "UpdateExternalPriceAccount",
+      "accounts": [
+        {
+          "name": "externalPriceAccount",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "External price account"
+        }
+      ],
+      "args": [
+        {
+          "name": "externalPriceAccount",
+          "type": {
+            "defined": "ExternalPriceAccount"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 9
+      }
+    },
+    {
+      "name": "SetAuthority",
+      "accounts": [
+        {
+          "name": "vault",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "Vault"
+        },
+        {
+          "name": "currentAuthority",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "Vault authority"
+        },
+        {
+          "name": "newAuthority",
+          "isMut": false,
+          "isSigner": false,
+          "desc": "New authority"
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 10
+      }
+    }
+  ],
+  "accounts": [
+    {
+      "name": "Vault",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "tokenProgram",
+            "type": "publicKey"
+          },
+          {
+            "name": "fractionMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "fractionTreasury",
+            "type": "publicKey"
+          },
+          {
+            "name": "redeemTreasury",
+            "type": "publicKey"
+          },
+          {
+            "name": "allowFurtherShareCreation",
+            "type": "bool"
+          },
+          {
+            "name": "pricingLookupAddress",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenTypeCount",
+            "type": "u8"
+          },
+          {
+            "name": "state",
+            "type": {
+              "defined": "VaultState"
+            }
+          },
+          {
+            "name": "lockedPricePerShare",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SafetyDepositBox",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "vault",
+            "type": "publicKey"
+          },
+          {
+            "name": "tokenMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "store",
+            "type": "publicKey"
+          },
+          {
+            "name": "order",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ExternalPriceAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "key",
+            "type": {
+              "defined": "Key"
+            }
+          },
+          {
+            "name": "pricePerShare",
+            "type": "u64"
+          },
+          {
+            "name": "priceMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "allowedToCombine",
+            "type": "bool"
+          }
+        ]
+      }
+    }
+  ],
+  "types": [
+    {
+      "name": "InitVaultArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "allowFurtherShareCreation",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AmountArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NumberOfShareArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "numberOfShares",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MintEditionProxyArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "edition",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Key",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Uninitialized"
+          },
+          {
+            "name": "SafetyDepositBoxV1"
+          },
+          {
+            "name": "ExternalAccountKeyV1"
+          },
+          {
+            "name": "VaultV1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Inactive"
+          },
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Combined"
+          },
+          {
+            "name": "Deactivated"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank",
+    "address": "vau1zxA2LbssAUEF7Gpw91zMM1LvXrvpzJtmZ58rPsn"
+  }
+}

--- a/test/integration/shank-token-vault.ts
+++ b/test/integration/shank-token-vault.ts
@@ -1,0 +1,15 @@
+import { Idl, Solita } from '../../src/solita'
+import test from 'tape'
+import path from 'path'
+import { verifySyntacticCorrectnessForGeneratedDir } from '../utils/verify-code'
+import json from './fixtures/shank_token_vault.json'
+
+const outputDir = path.join(__dirname, 'output', 'shank-token-vault')
+const generatedSDKDir = path.join(outputDir, 'generated')
+
+test('renders type correct SDK for shank_token_vault', async (t) => {
+  const idl = json as Idl
+  const gen = new Solita(idl, { formatCode: true })
+  await gen.renderAndWriteTo(generatedSDKDir)
+  await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
+})

--- a/test/render-accounts.ts
+++ b/test/render-accounts.ts
@@ -23,11 +23,9 @@ async function checkRenderedAccount(
   opts: {
     logImports: boolean
     logCode: boolean
-    userDefinedEnums?: Set<string>
   } = { logImports: DIAGNOSTIC_ON, logCode: DIAGNOSTIC_ON }
 ) {
-  const { userDefinedEnums = new Set() } = opts
-  const ts = renderAccount(account, FORCE_FIXABLE_NEVER, userDefinedEnums, true)
+  const ts = renderAccount(account, FORCE_FIXABLE_NEVER, true)
 
   if (opts.logCode) {
     console.log(

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -24,16 +24,9 @@ async function checkRenderedIx(
   opts: {
     logImports: boolean
     logCode: boolean
-    userDefinedEnums?: Set<string>
   } = { logImports: DIAGNOSTIC_ON, logCode: DIAGNOSTIC_ON }
 ) {
-  const { userDefinedEnums = new Set() } = opts
-  const ts = renderInstruction(
-    ix,
-    PROGRAM_ID,
-    FORCE_FIXABLE_NEVER,
-    userDefinedEnums
-  )
+  const ts = renderInstruction(ix, PROGRAM_ID, FORCE_FIXABLE_NEVER)
   verifySyntacticCorrectness(t, ts)
 
   const analyzed = await analyzeCode(ts)

--- a/test/type-mapper.ts
+++ b/test/type-mapper.ts
@@ -301,7 +301,7 @@ test('type-mapper: composite types - user defined', (t) => {
   tm.clearUsages()
 
   const serde = tm.mapSerde(type)
-  t.equal(serde, 'definedTypes.configDataStruct')
+  t.equal(serde, 'definedTypes.configDataBeet')
   spok(t, Array.from(tm.serdePackagesUsed), {
     $topic: 'serdePackagesUsed',
     ...[LOCAL_TYPES_PACKAGE],
@@ -438,7 +438,7 @@ test('type-mapper: composite types multilevel - vec<option<ConfigData>>', (t) =>
 
   tm.clearUsages()
   const serde = tm.mapSerde(type)
-  t.equal(serde, 'beet.array(beet.coption(definedTypes.configDataStruct))')
+  t.equal(serde, 'beet.array(beet.coption(definedTypes.configDataBeet))')
   spok(t, Array.from(tm.serdePackagesUsed), {
     $topic: 'serdePackagesUsed',
     ...[LOCAL_TYPES_PACKAGE, BEET_PACKAGE],
@@ -528,11 +528,11 @@ test('type-mapper: serde fields', (t) => {
       },
       {
         name: 'configData',
-        type: 'definedTypes.configDataStruct',
+        type: 'definedTypes.configDataBeet',
       },
       {
         name: 'vecOptionConfigData',
-        type: 'beet.array(beet.coption(definedTypes.configDataStruct))',
+        type: 'beet.array(beet.coption(definedTypes.configDataBeet))',
       },
     ])
 


### PR DESCRIPTION
This PR contains the following fixes and improvements applied while using solita in a few
scenarios:

- types: simplified naming of enum/struct beets
- code: rendering main index file that reesports all generated folders
- ix: including instruction account attributes in comment
- ix: accounts docs don't include known pubkeys
- accounts: allow them to be imported via `defined` like types
