### PR TITLE
fix: improved local imports to avoid circular references

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.0.8",
-    "@metaplex-foundation/beet-solana": "^0.0.6",
-    "@solana/web3.js": "^1.35.0",
+    "@metaplex-foundation/beet": "^0.1.0",
+    "@metaplex-foundation/beet-solana": "^0.1.1",
+    "@solana/web3.js": "^1.36.0",
     "camelcase": "^6.2.1",
     "debug": "^4.3.3",
     "js-sha256": "^0.9.0",

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,6 +1,7 @@
 import { PathLike } from 'fs'
 import path from 'path'
 
+// write a file
 export class Paths {
   constructor(readonly outputDir: PathLike) {}
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,42 @@
+import { PathLike } from 'fs'
+import path from 'path'
+
+export class Paths {
+  constructor(readonly outputDir: PathLike) {}
+
+  get root() {
+    return this.outputDir.toString()
+  }
+
+  get accountsDir() {
+    return path.join(this.outputDir.toString(), 'accounts')
+  }
+
+  get instructionsDir() {
+    return path.join(this.outputDir.toString(), 'instructions')
+  }
+
+  get typesDir() {
+    return path.join(this.outputDir.toString(), 'types')
+  }
+
+  get errorsDir() {
+    return path.join(this.outputDir.toString(), 'errors')
+  }
+
+  accountFile(name: string) {
+    return path.join(this.accountsDir, `${name}.ts`)
+  }
+
+  instructionFile(name: string) {
+    return path.join(this.instructionsDir, `${name}.ts`)
+  }
+
+  typeFile(name: string) {
+    return path.join(this.typesDir, `${name}.ts`)
+  }
+
+  errorFile(name: string) {
+    return path.join(this.errorsDir, `${name}.ts`)
+  }
+}

--- a/src/render-account.ts
+++ b/src/render-account.ts
@@ -1,3 +1,4 @@
+import { PathLike } from 'fs'
 import { renderScalarEnums } from './render-enums'
 import { renderDataStruct } from './serdes'
 import { ForceFixable, TypeMapper } from './type-mapper'
@@ -32,6 +33,7 @@ class AccountRenderer {
 
   constructor(
     private readonly account: IdlAccount,
+    private readonly fullFileDir: PathLike,
     private readonly hasImplicitDiscriminator: boolean,
     private readonly resolveFieldType: ResolveFieldType,
     private readonly typeMapper: TypeMapper
@@ -88,7 +90,8 @@ class AccountRenderer {
   // Imports
   // -----------------
   private renderImports() {
-    const imports = this.typeMapper.importsForSerdePackagesUsed(
+    const imports = this.typeMapper.importsUsed(
+      this.fullFileDir.toString(),
       new Set([SOLANA_WEB3_PACKAGE, BEET_PACKAGE])
     )
     return imports.join('\n')
@@ -371,15 +374,21 @@ ${beetDecl}`
 
 export function renderAccount(
   account: IdlAccount,
-  accountTypes: Set<string>,
-  customTypes: Set<string>,
+  fullFileDir: PathLike,
+  accountFilesByType: Map<string, string>,
+  customFilesByType: Map<string, string>,
   forceFixable: ForceFixable,
   resolveFieldType: ResolveFieldType,
   hasImplicitDiscriminator: boolean
 ) {
-  const typeMapper = new TypeMapper(accountTypes, customTypes, forceFixable)
+  const typeMapper = new TypeMapper(
+    accountFilesByType,
+    customFilesByType,
+    forceFixable
+  )
   const renderer = new AccountRenderer(
     account,
+    fullFileDir,
     hasImplicitDiscriminator,
     resolveFieldType,
     typeMapper

--- a/src/render-type.ts
+++ b/src/render-type.ts
@@ -8,6 +8,7 @@ import {
 import { strict as assert } from 'assert'
 import { renderTypeDataStruct, serdePackageExportName } from './serdes'
 import { renderScalarEnum } from './render-enums'
+import { PathLike } from 'fs'
 
 export function beetVarNameFromTypeName(ty: string) {
   const camelTyName = ty.charAt(0).toLowerCase().concat(ty.slice(1))
@@ -20,6 +21,7 @@ class TypeRenderer {
   readonly beetArgName: string
   constructor(
     readonly ty: IdlDefinedTypeDefinition,
+    readonly fullFileDir: PathLike,
     readonly typeMapper = new TypeMapper()
   ) {
     this.upperCamelTyName = ty.name
@@ -62,7 +64,7 @@ class TypeRenderer {
   // Imports
   // -----------------
   private renderImports() {
-    const imports = this.typeMapper.importsForSerdePackagesUsed()
+    const imports = this.typeMapper.importsUsed(this.fullFileDir)
     return imports.join('\n')
   }
 
@@ -114,11 +116,12 @@ export ${dataStruct}
 
 export function renderType(
   ty: IdlDefinedTypeDefinition,
-  accountTypes: Set<string>,
-  customTypes: Set<string>
+  fullFileDir: PathLike,
+  accountFilesByType: Map<string, string>,
+  customFilesByType: Map<string, string>
 ) {
-  const typeMapper = new TypeMapper(accountTypes, customTypes)
-  const renderer = new TypeRenderer(ty, typeMapper)
+  const typeMapper = new TypeMapper(accountFilesByType, customFilesByType)
+  const renderer = new TypeRenderer(ty, fullFileDir, typeMapper)
   const code = renderer.render()
   const isFixable = renderer.typeMapper.usedFixableSerde
   return { code, isFixable }

--- a/src/solita.ts
+++ b/src/solita.ts
@@ -133,7 +133,7 @@ export class Solita {
         }
         let { code, isFixable } = renderType(
           ty,
-          this.paths!.typeFile(ty.name),
+          this.paths!.typesDir,
           accountFiles,
           customFiles
         )

--- a/src/solita.ts
+++ b/src/solita.ts
@@ -4,6 +4,7 @@ import { renderAccount } from './render-account'
 import { renderErrors } from './render-errors'
 import { renderInstruction } from './render-instruction'
 import { renderType } from './render-type'
+import { strict as assert } from 'assert'
 import {
   Idl,
   IdlType,
@@ -21,6 +22,7 @@ import {
   prependGeneratedWarning,
 } from './utils'
 import { format, Options } from 'prettier'
+import { Paths } from './paths'
 
 export * from './types'
 
@@ -44,6 +46,7 @@ export class Solita {
   private readonly formatOpts: Options
   private readonly accountsHaveImplicitDiscriminator: boolean
   private readonly prependGeneratedWarning: boolean
+  private paths: Paths | undefined
   constructor(
     private readonly idl: Idl,
     {
@@ -217,78 +220,72 @@ export class Solita {
   }
 
   async renderAndWriteTo(outputDir: PathLike) {
+    this.paths = new Paths(outputDir)
     const { instructions, accounts, types, errors } = this.renderCode()
     const reexports = ['instructions']
-    await this.writeInstructions(outputDir, instructions)
+    await this.writeInstructions(instructions)
 
     if (Object.keys(accounts).length !== 0) {
       reexports.push('accounts')
-      await this.writeAccounts(outputDir, accounts)
+      await this.writeAccounts(accounts)
     }
     if (Object.keys(types).length !== 0) {
       reexports.push('types')
-      await this.writeTypes(outputDir, types)
+      await this.writeTypes(types)
     }
     if (errors != null) {
       reexports.push('errors')
-      await this.writeErrors(outputDir, errors)
+      await this.writeErrors(errors)
     }
 
-    await this.writeMainIndex(outputDir, reexports)
+    await this.writeMainIndex(reexports)
   }
 
   // -----------------
   // Instructions
   // -----------------
-  private async writeInstructions(
-    outputDir: PathLike,
-    instructions: Record<string, string>
-  ) {
-    const instructionsDir = path.join(outputDir.toString(), 'instructions')
-    await prepareTargetDir(instructionsDir)
-    logInfo('Writing instructions to directory: %s', instructionsDir)
+  private async writeInstructions(instructions: Record<string, string>) {
+    assert(this.paths != null, 'should have set paths')
+
+    await prepareTargetDir(this.paths.instructionsDir)
+    logInfo('Writing instructions to directory: %s', this.paths.instructionsDir)
     for (const [name, code] of Object.entries(instructions)) {
       logDebug('Writing instruction: %s', name)
-      await fs.writeFile(path.join(instructionsDir, `${name}.ts`), code, 'utf8')
+      await fs.writeFile(this.paths.instructionFile(name), code, 'utf8')
     }
     logDebug('Writing index.ts exporting all instructions')
     const indexCode = renderImportIndex(Object.keys(instructions).sort())
-    await fs.writeFile(
-      path.join(instructionsDir, `index.ts`),
-      indexCode,
-      'utf8'
-    )
+    await fs.writeFile(this.paths.instructionFile('index'), indexCode, 'utf8')
   }
 
   // -----------------
   // Accounts
   // -----------------
-  private async writeAccounts(
-    outputDir: PathLike,
-    accounts: Record<string, string>
-  ) {
-    const accountsDir = path.join(outputDir.toString(), 'accounts')
-    await prepareTargetDir(accountsDir)
-    logInfo('Writing accounts to directory: %s', accountsDir)
+  private async writeAccounts(accounts: Record<string, string>) {
+    assert(this.paths != null, 'should have set paths')
+
+    await prepareTargetDir(this.paths.accountsDir)
+    logInfo('Writing accounts to directory: %s', this.paths.accountsDir)
     for (const [name, code] of Object.entries(accounts)) {
       logDebug('Writing account: %s', name)
-      await fs.writeFile(path.join(accountsDir, `${name}.ts`), code, 'utf8')
+      await fs.writeFile(this.paths.accountFile(name), code, 'utf8')
     }
     logDebug('Writing index.ts exporting all accounts')
     const indexCode = renderImportIndex(Object.keys(accounts).sort())
-    await fs.writeFile(path.join(accountsDir, `index.ts`), indexCode, 'utf8')
+    await fs.writeFile(this.paths.accountFile('index'), indexCode, 'utf8')
   }
 
   // -----------------
   // Types
   // -----------------
-  private async writeTypes(outputDir: PathLike, types: Record<string, string>) {
-    const typesDir = path.join(outputDir.toString(), 'types')
-    await prepareTargetDir(typesDir)
-    logInfo('Writing types to directory: %s', typesDir)
+  private async writeTypes(types: Record<string, string>) {
+    assert(this.paths != null, 'should have set paths')
+
+    await prepareTargetDir(this.paths.typesDir)
+    logInfo('Writing types to directory: %s', this.paths.typesDir)
     for (const [name, code] of Object.entries(types)) {
       logDebug('Writing type: %s', name)
-      await fs.writeFile(path.join(typesDir, `${name}.ts`), code, 'utf8')
+      await fs.writeFile(this.paths.typeFile(name), code, 'utf8')
     }
     logDebug('Writing index.ts exporting all types')
     const reexports = Object.keys(types)
@@ -296,25 +293,28 @@ export class Solita {
     // it would break if we have an account used that way, but no types
     // If that occurs we need to generate the `types/index.ts` just reexporting accounts
     const indexCode = renderImportIndex(reexports.sort())
-    await fs.writeFile(path.join(typesDir, `index.ts`), indexCode, 'utf8')
+    await fs.writeFile(this.paths.typeFile('index'), indexCode, 'utf8')
   }
 
   // -----------------
   // Errors
   // -----------------
-  private async writeErrors(outputDir: PathLike, errorsCode: string) {
-    const errorsDir = path.join(outputDir.toString(), 'errors')
-    await prepareTargetDir(errorsDir)
-    logInfo('Writing errors to directory: %s', errorsDir)
+  private async writeErrors(errorsCode: string) {
+    assert(this.paths != null, 'should have set paths')
+
+    await prepareTargetDir(this.paths.errorsDir)
+    logInfo('Writing errors to directory: %s', this.paths.errorsDir)
     logDebug('Writing index.ts containing all errors')
-    await fs.writeFile(path.join(errorsDir, `index.ts`), errorsCode, 'utf8')
+    await fs.writeFile(this.paths.errorFile('index'), errorsCode, 'utf8')
   }
 
   // -----------------
   // Main Index File
   // -----------------
 
-  async writeMainIndex(outputDir: PathLike, reexports: string[]) {
+  async writeMainIndex(reexports: string[]) {
+    assert(this.paths != null, 'should have set paths')
+
     const programAddress = this.idl.metadata.address
     const reexportCode = renderImportIndex(reexports.sort())
     const imports = `import { PublicKey } from '${SOLANA_WEB3_PACKAGE}'`
@@ -350,10 +350,6 @@ ${programIdConsts}
       }
     }
 
-    await fs.writeFile(
-      path.join(outputDir.toString(), `index.ts`),
-      code,
-      'utf8'
-    )
+    await fs.writeFile(path.join(this.paths.root, `index.ts`), code, 'utf8')
   }
 }

--- a/src/type-mapper.ts
+++ b/src/type-mapper.ts
@@ -13,12 +13,10 @@ import {
   isIdlTypeEnum,
   isIdlTypeOption,
   isIdlTypeVec,
-  LOCAL_ACCOUNTS_PACKAGE,
-  LOCAL_TYPES_PACKAGE,
   PrimaryTypeMap,
   TypeMappedSerdeField,
 } from './types'
-import { logDebug } from './utils'
+import { getOrCreate, logDebug, withoutTsExtension } from './utils'
 import { strict as assert } from 'assert'
 import {
   BeetTypeMapKey,
@@ -36,6 +34,8 @@ import {
   serdePackageExportName,
 } from './serdes'
 import { beetVarNameFromTypeName } from './render-type'
+import path from 'path'
+import { PathLike } from 'fs'
 
 export function resolveSerdeAlias(ty: string) {
   switch (ty) {
@@ -52,17 +52,21 @@ export const FORCE_FIXABLE_NEVER: ForceFixable = () => false
 const NO_NAME_PROVIDED = '<no name provided>'
 export class TypeMapper {
   readonly serdePackagesUsed: Set<SerdePackage> = new Set()
+  readonly localImportsByPath: Map<string, Set<string>> = new Map()
   readonly scalarEnumsUsed: Map<string, string[]> = new Map()
   usedFixableSerde: boolean = false
   constructor(
-    private readonly accountTypes: Set<string> = new Set(),
-    private readonly customTypes: Set<string> = new Set(),
+    /** Account types mapped { typeName: fullPath } */
+    private readonly accountTypesPaths: Map<string, string> = new Map(),
+    /** Custom types mapped { typeName: fullPath } */
+    private readonly customTypesPaths: Map<string, string> = new Map(),
     private readonly forceFixable: ForceFixable = FORCE_FIXABLE_NEVER,
     private readonly primaryTypeMap: PrimaryTypeMap = TypeMapper.defaultPrimaryTypeMap
   ) {}
 
   clearUsages() {
     this.serdePackagesUsed.clear()
+    this.localImportsByPath.clear()
     this.usedFixableSerde = false
     this.scalarEnumsUsed.clear()
   }
@@ -126,10 +130,10 @@ export class TypeMapper {
   }
 
   private mapDefinedType(ty: IdlTypeDefined) {
-    const definedTypePackage: SerdePackage = this.definedTypesPackage(ty)
-    this.serdePackagesUsed.add(definedTypePackage)
-    const exp = serdePackageExportName(definedTypePackage)
-    return `${exp}.${ty.defined}`
+    const fullFileDir = this.definedTypesImport(ty)
+    const imports = getOrCreate(this.localImportsByPath, fullFileDir, new Set())
+    imports.add(ty.defined)
+    return ty.defined
   }
 
   private mapEnumType(ty: IdlTypeEnum, name: string) {
@@ -233,11 +237,11 @@ export class TypeMapper {
   }
 
   private mapDefinedSerde(ty: IdlTypeDefined) {
-    const definedTypePackage: SerdePackage = this.definedTypesPackage(ty)
-    this.serdePackagesUsed.add(definedTypePackage)
-    const exp = serdePackageExportName(definedTypePackage)
+    const fullFileDir = this.definedTypesImport(ty)
+    const imports = getOrCreate(this.localImportsByPath, fullFileDir, new Set())
     const varName = beetVarNameFromTypeName(ty.defined)
-    return `${exp}.${varName}`
+    imports.add(varName)
+    return varName
   }
 
   private mapEnumSerde(ty: IdlTypeEnum, name: string) {
@@ -296,8 +300,14 @@ export class TypeMapper {
   // -----------------
   // Imports Generator
   // -----------------
-  importsForSerdePackagesUsed(forcePackages?: Set<SerdePackage>) {
-    const imports = []
+  importsUsed(fileDir: PathLike, forcePackages?: Set<SerdePackage>) {
+    return [
+      ...this._importsForSerdePackages(forcePackages),
+      ...this._importsForLocalPackages(fileDir),
+    ]
+  }
+
+  private _importsForSerdePackages(forcePackages?: Set<SerdePackage>) {
     const packagesToInclude =
       forcePackages == null
         ? this.serdePackagesUsed
@@ -305,11 +315,24 @@ export class TypeMapper {
             ...Array.from(this.serdePackagesUsed),
             ...Array.from(forcePackages),
           ])
+    const imports = []
     for (const pack of packagesToInclude) {
       const exp = serdePackageExportName(pack)
       imports.push(`import * as ${exp} from '${pack}';`)
     }
     return imports
+  }
+
+  private _importsForLocalPackages(filePath: PathLike) {
+    const renderedImports: string[] = []
+    for (const [originPath, imports] of this.localImportsByPath) {
+      const relPath = path.relative(filePath.toString(), originPath)
+      const importPath = withoutTsExtension(relPath)
+      renderedImports.push(
+        `import { ${Array.from(imports).join(', ')} }  from '${importPath}';`
+      )
+    }
+    return renderedImports
   }
 
   assertBeetSupported(
@@ -321,16 +344,13 @@ export class TypeMapper {
       `Types to ${context} need to be supported by Beet, ${serde} is not`
     )
   }
-
-  private definedTypesPackage(ty: IdlTypeDefined) {
-    if (this.accountTypes.has(ty.defined)) {
-      return LOCAL_ACCOUNTS_PACKAGE
-    }
-    if (this.customTypes.has(ty.defined)) {
-      return LOCAL_TYPES_PACKAGE
-    }
-    assert.fail(
-      `Unknown type ${ty.defined} is neither found in types nor an Account`
+  private definedTypesImport(ty: IdlTypeDefined) {
+    return (
+      this.accountTypesPaths.get(ty.defined) ??
+      this.customTypesPaths.get(ty.defined) ??
+      assert.fail(
+        `Unknown type ${ty.defined} is neither found in types nor an Account`
+      )
     )
   }
 

--- a/src/type-mapper.ts
+++ b/src/type-mapper.ts
@@ -303,7 +303,7 @@ export class TypeMapper {
   importsUsed(fileDir: PathLike, forcePackages?: Set<SerdePackage>) {
     return [
       ...this._importsForSerdePackages(forcePackages),
-      ...this._importsForLocalPackages(fileDir),
+      ...this._importsForLocalPackages(fileDir.toString()),
     ]
   }
 
@@ -323,10 +323,13 @@ export class TypeMapper {
     return imports
   }
 
-  private _importsForLocalPackages(filePath: PathLike) {
+  private _importsForLocalPackages(fileDir: string) {
     const renderedImports: string[] = []
     for (const [originPath, imports] of this.localImportsByPath) {
-      const relPath = path.relative(filePath.toString(), originPath)
+      let relPath = path.relative(fileDir, originPath)
+      if (!relPath.startsWith('.')) {
+        relPath = `./${relPath}`
+      }
       const importPath = withoutTsExtension(relPath)
       renderedImports.push(
         `import { ${Array.from(imports).join(', ')} }  from '${importPath}';`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,10 @@ export const logInfo = debug('solita:info')
 export const logDebug = debug('solita:debug')
 export const logTrace = debug('solita:trace')
 
+// -----------------
+// FileSystem
+// -----------------
+
 /**
  * Ensures that the given directory exists by creating it recursively when necessary.
  * It also removes all existing files from the directory (non-recursively).
@@ -52,6 +56,10 @@ async function canAccess(p: PathLike) {
   } catch (_) {
     return false
   }
+}
+
+export function withoutTsExtension(p: string) {
+  return p.replace(/\.ts$/, '')
 }
 
 export function prependGeneratedWarning(code: string) {
@@ -126,4 +134,14 @@ export function anchorDiscriminatorType(
 ) {
   const ty: IdlTypeArray = { array: ['u8', 8] }
   return typeMapper.map(ty, context)
+}
+
+// -----------------
+// Maps
+// -----------------
+export function getOrCreate<K, V>(map: Map<K, V>, key: K, initial: V): V {
+  const current = map.get(key)
+  if (current != null) return current
+  map.set(key, initial)
+  return initial
 }

--- a/test/render-accounts.ts
+++ b/test/render-accounts.ts
@@ -16,6 +16,8 @@ import {
 
 const DIAGNOSTIC_ON = false
 
+const ACCOUNT_FILE_DIR = '/root/app/accounts/'
+
 async function checkRenderedAccount(
   t: Test,
   account: IdlAccount,
@@ -27,8 +29,9 @@ async function checkRenderedAccount(
 ) {
   const ts = renderAccount(
     account,
-    new Set(),
-    new Set(),
+    ACCOUNT_FILE_DIR,
+    new Map(),
+    new Map(),
     FORCE_FIXABLE_NEVER,
     (_: string) => null,
     true

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -16,6 +16,7 @@ import {
 const PROGRAM_ID = 'testprogram'
 
 const DIAGNOSTIC_ON = false
+const INSTRUCTION_FILE_DIR = '/root/app/instructions/'
 
 async function checkRenderedIx(
   t: Test,
@@ -28,9 +29,10 @@ async function checkRenderedIx(
 ) {
   const ts = renderInstruction(
     ix,
+    INSTRUCTION_FILE_DIR,
     PROGRAM_ID,
-    new Set(),
-    new Set(),
+    new Map(),
+    new Map(),
     FORCE_FIXABLE_NEVER
   )
   verifySyntacticCorrectness(t, ts)

--- a/test/render-type.ts
+++ b/test/render-type.ts
@@ -1,11 +1,7 @@
 import test, { Test } from 'tape'
 import { renderType } from '../src/render-type'
 import { SerdePackage } from '../src/serdes'
-import {
-  BEET_PACKAGE,
-  IdlDefinedTypeDefinition,
-  LOCAL_TYPES_PACKAGE,
-} from '../src/types'
+import { BEET_PACKAGE, IdlDefinedTypeDefinition } from '../src/types'
 import {
   analyzeCode,
   verifyImports,
@@ -13,6 +9,7 @@ import {
 } from './utils/verify-code'
 
 const DIAGNOSTIC_ON = false
+const TYPE_FILE_DIR = '/root/app/instructions/'
 
 async function checkRenderedType(
   t: Test,
@@ -23,7 +20,12 @@ async function checkRenderedType(
     logCode: boolean
   } = { logImports: DIAGNOSTIC_ON, logCode: DIAGNOSTIC_ON }
 ) {
-  const ts = renderType(ty, new Set(), new Set(['Creator']))
+  const ts = renderType(
+    ty,
+    TYPE_FILE_DIR,
+    new Map(),
+    new Map([['Creator', '/module/of/creator.ts']])
+  )
   verifySyntacticCorrectness(t, ts.code)
 
   const analyzed = await analyzeCode(ts.code)
@@ -111,6 +113,6 @@ test('types: with four fields, one referring to other defined type', async (t) =
     },
   }
 
-  await checkRenderedType(t, ty, [BEET_PACKAGE, LOCAL_TYPES_PACKAGE])
+  await checkRenderedType(t, ty, [BEET_PACKAGE])
   t.end()
 })

--- a/test/type-mapper.ts
+++ b/test/type-mapper.ts
@@ -25,6 +25,7 @@ test('type-mapper: primitive types - numbers', (t) => {
     t.equal(ty, 'number', `'${n}' maps to '${ty}' TypeScript type`)
   }
   t.notOk(tm.usedFixableSerde, 'did not use fixable serde')
+  t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
 
   tm.clearUsages()
   for (const n of types) {
@@ -36,6 +37,7 @@ test('type-mapper: primitive types - numbers', (t) => {
     ...[BEET_PACKAGE],
   })
   t.notOk(tm.usedFixableSerde, 'did not use fixable serde')
+  t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
   t.end()
 })
 
@@ -52,6 +54,7 @@ test('type-mapper: primitive types - bignums', (t) => {
     ...[BEET_PACKAGE],
   })
   t.notOk(tm.usedFixableSerde, 'did not use fixable serde')
+  t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
 
   tm.clearUsages()
   for (const n of types) {
@@ -72,6 +75,7 @@ test('type-mapper: primitive types - string', (t) => {
   const ty = tm.map('string')
   t.equal(ty, 'string', 'string type')
   t.equal(tm.serdePackagesUsed.size, 0, 'no serdePackagesUsed')
+  t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
 
   tm.clearUsages()
   const serde = tm.mapSerde('string')
@@ -133,6 +137,7 @@ test('type-mapper: enums scalar', (t) => {
       $topic: 'scalarEnumsUsed',
       ...[['MembershipModel', ['Wallet', 'Token', 'NFT']]],
     })
+    t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
 
     tm.clearUsages()
     const serde = tm.mapSerde(enumType, 'MembershipModel')
@@ -145,6 +150,7 @@ test('type-mapper: enums scalar', (t) => {
       $topic: 'scalarEnumsUsed',
       ...[['MembershipModel', ['Wallet', 'Token', 'NFT']]],
     })
+    t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
   }
   t.end()
 })
@@ -175,6 +181,7 @@ test('type-mapper: composite types - option<number | bignum>', (t) => {
       $topic: 'serdePackagesUsed',
       ...[BEET_PACKAGE],
     })
+    t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
     t.ok(tm.usedFixableSerde, 'used fixable serde')
   }
 
@@ -199,6 +206,7 @@ test('type-mapper: composite types - option<number | bignum>', (t) => {
       $topic: 'serdePackagesUsed',
       ...[BEET_PACKAGE],
     })
+    t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
     t.ok(tm.usedFixableSerde, 'used fixable serde')
   }
 
@@ -226,6 +234,7 @@ test('type-mapper: composite types - vec<number | bignum>', (t) => {
       $topic: 'serdePackagesUsed',
       ...[BEET_PACKAGE],
     })
+    t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
     t.ok(tm.usedFixableSerde, 'used fixable serde')
   }
 
@@ -249,6 +258,7 @@ test('type-mapper: composite types - vec<number | bignum>', (t) => {
       $topic: 'serdePackagesUsed',
       ...[BEET_PACKAGE],
     })
+    t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
     t.ok(tm.usedFixableSerde, 'used fixable serde')
   }
   t.end()
@@ -370,6 +380,7 @@ test('type-mapper: composite with type extensions - publicKey', (t) => {
     $topic: 'serdePackagesUsed',
     ...[BEET_SOLANA_PACKAGE, BEET_PACKAGE],
   })
+  t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
   t.ok(tm.usedFixableSerde, 'used fixable serde')
 
   t.end()
@@ -396,6 +407,7 @@ test('type-mapper: composite types multilevel - option<option<number>>', (t) => 
     $topic: 'serdePackagesUsed',
     ...[BEET_PACKAGE],
   })
+  t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
   t.ok(tm.usedFixableSerde, 'used fixable serde')
   t.end()
 })
@@ -421,6 +433,7 @@ test('type-mapper: composite types multilevel - option<option<publicKey>>', (t) 
     $topic: 'serdePackagesUsed',
     ...[BEET_SOLANA_PACKAGE, BEET_PACKAGE],
   })
+  t.equal(tm.localImportsByPath.size, 0, 'used no local imports')
   t.ok(tm.usedFixableSerde, 'used fixable serde')
 
   t.end()

--- a/test/utils/verify-code.ts
+++ b/test/utils/verify-code.ts
@@ -141,14 +141,20 @@ export async function verifySyntacticCorrectnessForGeneratedDir(
   t: Test,
   fullDirPath: string
 ) {
+  const rootName = path.dirname(fullDirPath).split(path.sep).pop()
   const files = await recursiveReaddir(fullDirPath)
   for (const file of files) {
-    t.comment(`+++ Syntactically checking ${path.relative(fullDirPath, file)}`)
+    t.comment(
+      `+++ Syntactically checking ${path.relative(
+        fullDirPath,
+        file
+      )} inside ${rootName}`
+    )
     const ts = await fs.readFile(file, 'utf8')
     await verifySyntacticCorrectness(t, ts)
   }
 }
-export async function verifyTopLevelScriptF(
+export async function verifyTopLevelScript(
   t: Test,
   file: string,
   relFile: string
@@ -167,12 +173,13 @@ export async function verifyTopLevelScriptForGeneratedDir(
   indexFilesOnly = true
 ) {
   let files = await recursiveReaddir(fullDirPath)
+  const rootName = path.dirname(fullDirPath).split(path.sep).pop()
   if (indexFilesOnly) {
     files = files.filter((x) => x.endsWith('index.ts'))
   }
   for (const file of files) {
     const relFile = path.relative(fullDirPath, file)
-    t.comment(`+++ Running ${relFile}`)
-    await verifyTopLevelScriptF(t, file, relFile)
+    t.comment(`+++ Running ${relFile} inside ${rootName}`)
+    await verifyTopLevelScript(t, file, relFile)
   }
 }


### PR DESCRIPTION
## Summary

This PR improves imports of local modules in order to avoid circular references.
Instead of importing _all_ defined types like `import * as definedTypes from '../types'` or
similar code generated by solita now imports exactly what it needs, i.e.:

```
import { Foo, foo } from '../types/foo'
```

or similar.

## Changes

To archieve this the type mapper was updated to track imports of local files and resolve them
relative to the file that imports them. Solita in turn passes down the directory for the file
that is currently being processed to the typemapper.

## Checks

Tests were updated to show this was changed properly and the integration tests were manually
inspected to generate these imports.

Additionally I did apply this to generate token-metadata SDK which resulted in correct code
without any circular references. The only issue still remaining was the _fixable_ types not
properly bubbling up. However after fixing just that issue the tests ran as they did before
after manually fixing circular refs.
