### PR TITLE
feat: support optional instruction accounts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,8 @@ export type IdlInstructionAccount = {
   name: string
   isMut: boolean
   isSigner: boolean
+  desc?: string
+  optional?: boolean
 }
 
 export type IdlType =

--- a/test/integration/fixtures/shank_token_metadata.json
+++ b/test/integration/fixtures/shank_token_metadata.json
@@ -282,7 +282,8 @@
           "name": "reservationList",
           "isMut": true,
           "isSigner": false,
-          "desc": "(Optional) Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list."
+          "desc": "Reservation List - If present, and you are on this list, you can get an edition number given by your position on the list.",
+          "optional": true
         }
       ],
       "args": [],
@@ -1165,13 +1166,15 @@
           "name": "useAuthorityRecord",
           "isMut": true,
           "isSigner": false,
-          "desc": "(Optional) Use Authority Record PDA If present the program Assumes a delegated use authority"
+          "desc": "Use Authority Record PDA If present the program Assumes a delegated use authority",
+          "optional": true
         },
         {
           "name": "burner",
           "isMut": false,
           "isSigner": false,
-          "desc": "(Optional) Program As Signer (Burner)"
+          "desc": "Program As Signer (Burner)",
+          "optional": true
         }
       ],
       "args": [
@@ -1371,7 +1374,8 @@
           "name": "collectionAuthorityRecord",
           "isMut": false,
           "isSigner": false,
-          "desc": "(Optional) Collection Authority Record PDA"
+          "desc": "Collection Authority Record PDA",
+          "optional": true
         }
       ],
       "args": [],
@@ -1521,7 +1525,8 @@
           "name": "collectionAuthorityRecord",
           "isMut": false,
           "isSigner": false,
-          "desc": "(Optional) Collection Authority Record PDA"
+          "desc": "Collection Authority Record PDA",
+          "optional": true
         }
       ],
       "args": [],


### PR DESCRIPTION
## Summary

Considers instruction accounts that have `option: true` configured in the IDL special.

## Example

Given `useAuthorityRecord` and `burner` are optional the generated code will first create the
required accounts meta array (`keys`) and then add code similar to the below:

```ts
if (useAuthorityRecord != null) {
  keys.push({
    pubkey: useAuthorityRecord,
    isWritable: true,
    isSigner: false,
  })
}

if (burner != null) {
  if (useAuthorityRecord == null) {
    throw new Error(
      "When providing 'burner' then 'useAuthorityRecord' need(s) to be provided as well."
    )
  }
  keys.push({
    pubkey: burner,
    isWritable: false,
    isSigner: false,
  })
}
```

NOTE: that it also ensures that for consecutive _optional_ accounts the previous accounts all
need to be supplied.

FIXES: #25 