### PR TITLE
chore: various fixes around types

### DIFF
--- a/.github/workflows/solita.yml
+++ b/.github/workflows/solita.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: yarn install
       run: |
-        yarn install --force
+        yarn install
 
     - name: yarn build, lint and test
       run: |

--- a/.github/workflows/solita.yml
+++ b/.github/workflows/solita.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: yarn install
       run: |
-        yarn install
+        yarn install --force
 
     - name: yarn build, lint and test
       run: |

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "esbuild": "^0.14.11",
     "esbuild-runner": "^2.2.1",
     "eslint": "^8.6.0",
+    "pkg-dir": "^5.0.0",
     "recursive-readdir": "^2.2.2",
     "rimraf": "^3.0.2",
     "spok": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.1.2",
+    "@metaplex-foundation/beet": "0.1.2",
     "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.36.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "0.1.2",
+    "@metaplex-foundation/beet": "^0.1.3",
     "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.36.0",
@@ -67,6 +67,7 @@
     "@types/node": "^16.11.12",
     "@types/prettier": "^2.4.2",
     "@types/recursive-readdir": "^2.2.0",
+    "@types/rimraf": "^3.0.2",
     "@types/tape": "^4.13.2",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.1.0",
+    "@metaplex-foundation/beet": "^0.1.2",
     "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.36.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.1.3",
+    "@metaplex-foundation/beet": "^0.1.4",
     "@metaplex-foundation/beet-solana": "^0.1.1",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.36.0",

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -180,6 +180,7 @@ ${typeMapperImports.join('\n')}`.trim()
   }
 
   private renderAccountsType(processedKeys: ProcessedAccountKey[]) {
+    if (processedKeys.length === 0) return ''
     const web3 = SOLANA_WEB3_EXPORT_NAME
     const fields = processedKeys
       .filter((x) => x.knownPubkey == null)
@@ -225,7 +226,19 @@ export type ${this.accountsTypename} = {
 `
   }
 
+  private renderAccountsParamDoc(processedKeys: ProcessedAccountKey[]) {
+    if (processedKeys.length === 0) return '  *'
+    return `  *
+  * @param accounts that will be accessed while the instruction is processed`
+  }
+
+  private renderAccountsArg(processedKeys: ProcessedAccountKey[]) {
+    if (processedKeys.length === 0) return ''
+    return `accounts: ${this.accountsTypename},\n`
+  }
+
   private renderAccountsDestructure(processedKeys: ProcessedAccountKey[]) {
+    if (processedKeys.length === 0) return ''
     const params = processedKeys
       .filter((x) => x.knownPubkey == null)
       .map((x) => `${x.name}`)
@@ -277,6 +290,8 @@ ${struct}`.trim()
     const argsStructType = this.renderDataStruct(processedArgs)
 
     const keys = this.renderIxAccountKeys(processedKeys)
+    const accountsParamDoc = this.renderAccountsParamDoc(processedKeys)
+    const accountsArg = this.renderAccountsArg(processedKeys)
     const accountsDestructure = this.renderAccountsDestructure(processedKeys)
     const instructionDisc = this.instructionDiscriminator.renderValue()
     const enums = renderScalarEnums(this.typeMapper.scalarEnumsUsed).join('\n')
@@ -292,7 +307,7 @@ ${struct}`.trim()
       this.ix.args.length === 0
         ? ['', '', '']
         : [
-            `\n * @param args to provide as instruction data to the program`,
+            `\n * @param args to provide as instruction data to the program\n  *`,
             `args: ${this.argsTypename}`,
             '...args',
           ]
@@ -306,16 +321,13 @@ const ${this.instructionDiscriminatorName} = ${instructionDisc};
 
 /**
  * Creates a _${this.upperCamelIxName}_ instruction.
- * 
- * @param accounts that will be accessed while the instruction is processed${createInstructionArgsComment}
- *
+${accountsParamDoc}${createInstructionArgsComment}
  * @category Instructions
  * @category ${this.upperCamelIxName}
  * @category generated
  */
 export function create${this.upperCamelIxName}Instruction(
-  accounts: ${this.accountsTypename},
-  ${createInstructionArgs}
+  ${accountsArg}${createInstructionArgs}
 ) {
   ${accountsDestructure}
   const [data ] = ${this.structArgName}.serialize({ 

--- a/src/render-type.ts
+++ b/src/render-type.ts
@@ -64,7 +64,10 @@ class TypeRenderer {
   // Imports
   // -----------------
   private renderImports() {
-    const imports = this.typeMapper.importsUsed(this.fullFileDir)
+    const imports = this.typeMapper.importsUsed(
+      this.fullFileDir,
+      new Set([BEET_PACKAGE])
+    )
     return imports.join('\n')
   }
 

--- a/test/anchor-examples/basic-0/programs/basic-0/src/lib.rs
+++ b/test/anchor-examples/basic-0/programs/basic-0/src/lib.rs
@@ -5,7 +5,7 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 #[program]
 mod basic_0 {
     use super::*;
-    pub fn initialize(_ctx: Context<Initialize>) -> ProgramResult {
+    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
         Ok(())
     }
 }

--- a/test/anchor-examples/basic-0/test/initialize.ts
+++ b/test/anchor-examples/basic-0/test/initialize.ts
@@ -29,7 +29,7 @@ test('initialize', async (t) => {
 
   await amman.airdrop(connection, payer, 2)
 
-  const ix = createInitializeInstruction({})
+  const ix = createInitializeInstruction()
   const tx = new Transaction().add(ix)
   const res = await transactionHandler.sendAndConfirmTransaction(tx, [
     payerKeypair,

--- a/test/integration/auction-house-1.1.4-anchor-0.24.2.ts
+++ b/test/integration/auction-house-1.1.4-anchor-0.24.2.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/auction_house-1.1.4-anchor-0.24.2.json'
 
@@ -18,6 +19,7 @@ test('renders type correct SDK for auction house 1.1.4 using anchor-0.24.2', asy
   }
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/auction-house-1.1.4-anchor-0.24.2.ts
+++ b/test/integration/auction-house-1.1.4-anchor-0.24.2.ts
@@ -7,11 +7,14 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/auction_house-1.1.4-anchor-0.24.2.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'ah-1.1.4-anchor-0.24.2')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for auction house 1.1.4 using anchor-0.24.2', async (t) => {
+  rmrf(outputDir)
+
   const idl = json as Idl
   idl.metadata = {
     ...idl.metadata,

--- a/test/integration/auction-house.ts
+++ b/test/integration/auction-house.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/auction_house.json'
 
@@ -18,6 +19,7 @@ test('renders type correct SDK for auction house', async (t) => {
   }
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/auction-house.ts
+++ b/test/integration/auction-house.ts
@@ -7,11 +7,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/auction_house.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'ah')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for auction house', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   idl.metadata = {
     ...idl.metadata,

--- a/test/integration/fanout.ts
+++ b/test/integration/fanout.ts
@@ -7,11 +7,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/fanout.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'fanout')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for fanout', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   idl.metadata = {
     ...idl.metadata,

--- a/test/integration/fanout.ts
+++ b/test/integration/fanout.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/fanout.json'
 
@@ -18,6 +19,7 @@ test('renders type correct SDK for fanout', async (t) => {
   }
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/fixtures/issue-empty-accounts.json
+++ b/test/integration/fixtures/issue-empty-accounts.json
@@ -1,0 +1,37 @@
+{
+  "version": "0.1.0",
+  "name": "some-game",
+  "instructions": [
+    {
+      "name": "CompensateWinner",
+      "accounts": [],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    }
+  ],
+  "accounts": [],
+  "types": [
+    {
+      "name": "CompensateWinnerArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "game",
+            "type": "publicKey"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [],
+  "metadata": {
+    "origin": "shank",
+    "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+    "binaryVersion": "0.0.2",
+    "libVersion": "~0.0.2"
+  }
+}

--- a/test/integration/fixtures/issue-missing-beet-import.json
+++ b/test/integration/fixtures/issue-missing-beet-import.json
@@ -1,0 +1,51 @@
+{
+  "version": "0.1.0",
+  "name": "some-game",
+  "instructions": [
+    {
+      "name": "CompensateWinner",
+      "accounts": [
+        {
+          "name": "player",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "The player winning the game"
+        }
+      ],
+      "args": [
+        {
+          "name": "compensateWinnerArgs",
+          "type": {
+            "defined": "CompensateWinnerArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    }
+  ],
+  "accounts": [],
+  "types": [
+    {
+      "name": "CompensateWinnerArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "game",
+            "type": "publicKey"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [],
+  "metadata": {
+    "origin": "shank",
+    "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
+    "binaryVersion": "0.0.2",
+    "libVersion": "~0.0.2"
+  }
+}

--- a/test/integration/gumdrop.ts
+++ b/test/integration/gumdrop.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/gumdrop.json'
 
@@ -18,6 +19,7 @@ test('renders type correct SDK for gumdrop', async (t) => {
   }
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/gumdrop.ts
+++ b/test/integration/gumdrop.ts
@@ -7,11 +7,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/gumdrop.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'gumdrop')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for gumdrop', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   idl.metadata = {
     ...idl.metadata,

--- a/test/integration/issue-empty-accounts.ts
+++ b/test/integration/issue-empty-accounts.ts
@@ -1,0 +1,19 @@
+import { Idl, Solita } from '../../src/solita'
+import test from 'tape'
+import path from 'path'
+import {
+  verifySyntacticCorrectnessForGeneratedDir,
+  verifyTopLevelScriptForGeneratedDir,
+} from '../utils/verify-code'
+import json from './fixtures/issue-empty-accounts.json'
+
+const outputDir = path.join(__dirname, 'output', 'issue-empty-accounts')
+const generatedSDKDir = path.join(outputDir, 'generated')
+
+test('renders type correct SDK for issue-empty-accounts', async (t) => {
+  const idl = json as Idl
+  const gen = new Solita(idl, { formatCode: true })
+  await gen.renderAndWriteTo(generatedSDKDir)
+  await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
+  await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
+})

--- a/test/integration/issue-empty-accounts.ts
+++ b/test/integration/issue-empty-accounts.ts
@@ -7,11 +7,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/issue-empty-accounts.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'issue-empty-accounts')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for issue-empty-accounts', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)

--- a/test/integration/issue-empty-accounts.ts
+++ b/test/integration/issue-empty-accounts.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/issue-empty-accounts.json'
 
@@ -14,6 +15,7 @@ test('renders type correct SDK for issue-empty-accounts', async (t) => {
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/issue-missing-beet-import.ts
+++ b/test/integration/issue-missing-beet-import.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/issue-missing-beet-import.json'
 
@@ -14,6 +15,7 @@ test('renders type correct SDK for issue-missing-beet-import', async (t) => {
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/issue-missing-beet-import.ts
+++ b/test/integration/issue-missing-beet-import.ts
@@ -1,0 +1,19 @@
+import { Idl, Solita } from '../../src/solita'
+import test from 'tape'
+import path from 'path'
+import {
+  verifySyntacticCorrectnessForGeneratedDir,
+  verifyTopLevelScriptForGeneratedDir,
+} from '../utils/verify-code'
+import json from './fixtures/issue-missing-beet-import.json'
+
+const outputDir = path.join(__dirname, 'output', 'issue-missing-beet-import')
+const generatedSDKDir = path.join(outputDir, 'generated')
+
+test('renders type correct SDK for issue-missing-beet-import', async (t) => {
+  const idl = json as Idl
+  const gen = new Solita(idl, { formatCode: true })
+  await gen.renderAndWriteTo(generatedSDKDir)
+  await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
+  await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
+})

--- a/test/integration/issue-missing-beet-import.ts
+++ b/test/integration/issue-missing-beet-import.ts
@@ -7,11 +7,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/issue-missing-beet-import.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'issue-missing-beet-import')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for issue-missing-beet-import', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)

--- a/test/integration/nft-candy-machine-v1.ts
+++ b/test/integration/nft-candy-machine-v1.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/nft_candy_machine_v1.json'
 
@@ -18,6 +19,7 @@ test('renders type correct SDK for nft-candy-machine v1', async (t) => {
   }
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/nft-candy-machine-v1.ts
+++ b/test/integration/nft-candy-machine-v1.ts
@@ -7,11 +7,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/nft_candy_machine_v1.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'ncm')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for nft-candy-machine v1', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   idl.metadata = {
     ...idl.metadata,

--- a/test/integration/shank-tictactoe.ts
+++ b/test/integration/shank-tictactoe.ts
@@ -7,11 +7,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/shank_tictactoe.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'shank-tictactoe')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for shank_tictactoe', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)

--- a/test/integration/shank-tictactoe.ts
+++ b/test/integration/shank-tictactoe.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/shank_tictactoe.json'
 
@@ -14,6 +15,7 @@ test('renders type correct SDK for shank_tictactoe', async (t) => {
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/shank-token-metadata.ts
+++ b/test/integration/shank-token-metadata.ts
@@ -8,11 +8,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/shank_token_metadata.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'shank-token-metadata')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for shank_token_metadata and bubbles fixables', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)

--- a/test/integration/shank-token-metadata.ts
+++ b/test/integration/shank-token-metadata.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/shank_token_metadata.json'
 
@@ -15,6 +16,7 @@ test('renders type correct SDK for shank_token_metadata and bubbles fixables', a
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 

--- a/test/integration/shank-token-vault.ts
+++ b/test/integration/shank-token-vault.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import {
   verifySyntacticCorrectnessForGeneratedDir,
   verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/shank_token_vault.json'
 
@@ -14,6 +15,7 @@ test('renders type correct SDK for shank_token_vault', async (t) => {
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
   await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
   await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
 })

--- a/test/integration/shank-token-vault.ts
+++ b/test/integration/shank-token-vault.ts
@@ -7,11 +7,13 @@ import {
   verifyWithTypescriptCompiler,
 } from '../utils/verify-code'
 import json from './fixtures/shank_token_vault.json'
+import { sync as rmrf } from 'rimraf'
 
 const outputDir = path.join(__dirname, 'output', 'shank-token-vault')
 const generatedSDKDir = path.join(outputDir, 'generated')
 
 test('renders type correct SDK for shank_token_vault', async (t) => {
+  rmrf(outputDir)
   const idl = json as Idl
   const gen = new Solita(idl, { formatCode: true })
   await gen.renderAndWriteTo(generatedSDKDir)

--- a/test/utils/tsc.ts
+++ b/test/utils/tsc.ts
@@ -1,0 +1,72 @@
+import { writeFile } from 'fs/promises'
+import path from 'path'
+import packageDirectory from 'pkg-dir'
+
+import { spawn } from 'child_process'
+
+const config = {
+  compilerOptions: {
+    target: 'ES2018',
+    module: 'commonjs',
+    baseUrl: './',
+    sourceMap: false,
+    declaration: true,
+    declarationMap: false,
+    noEmit: true,
+    preserveWatchOutput: true,
+    emitDeclarationOnly: false,
+    importHelpers: false,
+    strict: true,
+    noUnusedLocals: true,
+    noFallthroughCasesInSwitch: true,
+    allowSyntheticDefaultImports: true,
+    esModuleInterop: true,
+    incremental: false,
+    types: ['node'],
+    moduleResolution: 'node',
+    noImplicitReturns: true,
+    skipLibCheck: true,
+    resolveJsonModule: false,
+  },
+  include: ['generated'],
+}
+
+async function resolveBin(bin: string) {
+  const root = (await packageDirectory()) as string
+  return path.join(root, 'node_modules', '.bin', bin)
+}
+
+async function writeTsconfig(parentToGeneratedDir: string) {
+  const tsconfigPath = path.join(parentToGeneratedDir, 'tsconfig.json')
+  await writeFile(tsconfigPath, JSON.stringify(config, null, 2))
+}
+
+export async function verifyTypes(fullPathToGeneratedDir: string) {
+  const parent = path.dirname(fullPathToGeneratedDir)
+  await writeTsconfig(parent)
+  const args = ['-p', 'tsconfig.json']
+
+  const tscExecutable = await resolveBin('tsc')
+  // const cmd = `${tscExecutable} ${args.join(' ')}`
+
+  return new Promise<void>((resolve, reject) => {
+    let loggedFailure = false
+    let failures = Buffer.from('')
+    const tsc = spawn(tscExecutable, args, { cwd: parent })
+      .on('error', (err) => {
+        reject(err)
+      })
+      .on('exit', () => {
+        return loggedFailure
+          ? reject(new Error(failures.toString('utf8')))
+          : resolve()
+      })
+    tsc.stdout.on('data', (buf) => {
+      loggedFailure = true
+      failures = Buffer.concat([failures, buf])
+    })
+    tsc.stderr.on('data', (buf) => {
+      process.stderr.write(buf)
+    })
+  })
+}

--- a/test/utils/verify-code.ts
+++ b/test/utils/verify-code.ts
@@ -15,6 +15,7 @@ import recursiveReaddir from 'recursive-readdir'
 
 import { exec as execCb } from 'child_process'
 import { promisify } from 'util'
+import { verifyTypes } from './tsc'
 const exec = promisify(execCb)
 const esr = path.join(
   require.resolve('esbuild-runner'),
@@ -181,5 +182,17 @@ export async function verifyTopLevelScriptForGeneratedDir(
     const relFile = path.relative(fullDirPath, file)
     t.comment(`+++ Running ${relFile} inside ${rootName}`)
     await verifyTopLevelScript(t, file, relFile)
+  }
+}
+
+export async function verifyWithTypescriptCompiler(
+  t: Test,
+  fullDirPath: string
+) {
+  try {
+    await verifyTypes(fullDirPath)
+    t.pass('Verifying types with tsc')
+  } catch (err) {
+    t.error(err, 'Verifying types with tsc')
   }
 }


### PR DESCRIPTION
## Missing Beet Import

- test: adding missing beet import integration test
- chore: fix missing beet import

## Handling empty Instruction Accounts

- test: showing empty ix accounts issue
- chore: handle empty ix accounts correclty

## Stricter Type Testing for Integration Tests
- chore: adding test util to typecheck code with tsc
- test: verifying with tsc for all existing tests

## Anchor Example Fix

- basic-0: fix rust return type
- basic-0: adapt test to no longer needing empty account arg

## Beet Type Issue

- fixed in beet -> bumped it
