### PR TITLE
Feat: Export IX Beet struct and ix discriminator

### DIFF
--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -317,7 +317,7 @@ ${enums}
 ${ixArgType}
 ${argsStructType}
 ${accountsType}
-const ${this.instructionDiscriminatorName} = ${instructionDisc};
+export const ${this.instructionDiscriminatorName} = ${instructionDisc};
 
 /**
  * Creates a _${this.upperCamelIxName}_ instruction.

--- a/src/serdes.ts
+++ b/src/serdes.ts
@@ -155,7 +155,7 @@ export function renderDataStruct({
     // -----------------
     // Beet Args Struct (Instruction)
     // -----------------
-    return `const ${structVarName} = new ${BEET_EXPORT_NAME}.${beetArgsStructType}<${structType}>(
+    return `export const ${structVarName} = new ${BEET_EXPORT_NAME}.${beetArgsStructType}<${structType}>(
   [
     ${discriminatorDecl}
     ${fieldDecls}


### PR DESCRIPTION
Small change to export the instruction discriminator and the instruction beet struct. This will enable us to expose this to Amman