### PR TITLE
feat: render padded account code

### DIFF
--- a/src/render-account.ts
+++ b/src/render-account.ts
@@ -9,7 +9,6 @@ import {
   BEET_PACKAGE,
   hasPaddingAttr,
   IdlAccount,
-  isIdlTypeArray,
   isIdlTypeDataEnum,
   isIdlTypeDefined,
   isIdlTypeScalarEnum,
@@ -422,6 +421,7 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
       discriminatorName,
       discriminatorField,
       discriminatorType,
+      paddingField: this.paddingField,
       isFixable: this.typeMapper.usedFixableSerde,
     })
     return `

--- a/src/serdes.ts
+++ b/src/serdes.ts
@@ -105,11 +105,13 @@ export function renderDataStruct({
   discriminatorField,
   discriminatorName,
   discriminatorType,
+  paddingField,
   isFixable,
 }: {
   discriminatorName?: string
   discriminatorField?: TypeMappedSerdeField
   discriminatorType?: string
+  paddingField?: { name: string; size: number }
   fields: TypeMappedSerdeField[]
   structVarName: string
   className?: string
@@ -120,15 +122,23 @@ export function renderDataStruct({
   const discriminatorDecl = renderField(discriminatorField, true)
   discriminatorType = discriminatorType ?? 'number[]'
 
+  const extraFields = []
+  if (discriminatorName != null) {
+    extraFields.push(`${discriminatorName}: ${discriminatorType}`)
+  }
+  if (paddingField != null) {
+    extraFields.push(
+      `${paddingField.name}: number[] /* size: ${paddingField.size} */`
+    )
+  }
+
   let structType =
     fields.length === 0
-      ? discriminatorName == null
-        ? ''
-        : `{ ${discriminatorName}: ${discriminatorType}; }`
-      : discriminatorName == null
+      ? extraFields.join('\n    ')
+      : extraFields.length === 0
       ? argsTypename
       : `${argsTypename} & {
-    ${discriminatorName}: ${discriminatorType};
+      ${extraFields.join('\n      ')}
   }
 `
 

--- a/src/serdes.ts
+++ b/src/serdes.ts
@@ -134,7 +134,7 @@ export function renderDataStruct({
 
   let structType =
     fields.length === 0
-      ? extraFields.join('\n    ')
+      ? `{ ${extraFields.join('\n    ')} }`
       : extraFields.length === 0
       ? argsTypename
       : `${argsTypename} & {

--- a/src/solita.ts
+++ b/src/solita.ts
@@ -53,6 +53,7 @@ export class Solita {
   private readonly typeAliases: Map<string, PrimitiveTypeKey>
   private readonly serializers: CustomSerializers
   private readonly projectRoot: string
+  private readonly hasInstructions: boolean
   private paths: Paths | undefined
   constructor(
     private readonly idl: Idl,
@@ -82,6 +83,7 @@ export class Solita {
       this.projectRoot,
       new Map(Object.entries(serializers))
     )
+    this.hasInstructions = idl.instructions.length > 0
   }
 
   // -----------------
@@ -284,8 +286,12 @@ export class Solita {
   async renderAndWriteTo(outputDir: PathLike) {
     this.paths = new Paths(outputDir)
     const { instructions, accounts, types, errors } = this.renderCode()
-    const reexports = ['instructions']
-    await this.writeInstructions(instructions)
+    const reexports = []
+
+    if (this.hasInstructions) {
+      reexports.push('instructions')
+      await this.writeInstructions(instructions)
+    }
 
     if (Object.keys(accounts).length !== 0) {
       reexports.push('accounts')

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import {
   BeetSolanaTypeMapKey,
 } from '@metaplex-foundation/beet-solana'
 import { SerdePackage } from './serdes'
+import { strict as assert } from 'assert'
 
 // -----------------
 // Config
@@ -197,6 +198,11 @@ export function isIdlTypeVec(ty: IdlType): ty is IdlTypeVec {
 
 export function isIdlTypeArray(ty: IdlType): ty is IdlTypeArray {
   return (ty as IdlTypeArray).array != null
+}
+
+export function asIdlTypeArray(ty: IdlType): IdlTypeArray {
+  assert(isIdlTypeArray(ty))
+  return ty
 }
 
 export function isIdlTypeDefined(ty: IdlType): ty is IdlTypeDefined {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,9 @@ export type Serializers = Record<string, string>
 export type IdlField = {
   name: string
   type: IdlType
+  attrs?: string[]
 }
+export const IDL_FIELD_ATTR_PADDING = 'padding'
 
 export type IdlInstructionAccount = {
   name: string
@@ -244,6 +246,10 @@ export function isIdlInstructionAccountWithDesc(
   ty: IdlInstructionAccount
 ): ty is IdlInstructionAccountWithDesc {
   return typeof (ty as IdlInstructionAccountWithDesc).desc === 'string'
+}
+
+export function hasPaddingAttr(field: IdlField): boolean {
+  return field.attrs != null && field.attrs.includes(IDL_FIELD_ATTR_PADDING)
 }
 
 // -----------------

--- a/test/integration/feat-account-padding.ts
+++ b/test/integration/feat-account-padding.ts
@@ -1,0 +1,25 @@
+import { Idl, Solita } from '../../src/solita'
+import test from 'tape'
+import path from 'path'
+import {
+  verifySyntacticCorrectnessForGeneratedDir,
+  verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
+} from '../utils/verify-code'
+import json from './fixtures/feat-account-padding.json'
+import { sync as rmrf } from 'rimraf'
+
+const outputDir = path.join(__dirname, 'output', 'feat-account-padding')
+const generatedSDKDir = path.join(outputDir, 'generated')
+
+test('renders type correct SDK for feat-account-padding', async (t) => {
+  rmrf(outputDir)
+  const idl = json as Idl
+  const gen = new Solita(idl, {
+    formatCode: true,
+  })
+  await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
+  await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
+  await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
+})

--- a/test/integration/fixtures/feat-account-padding.json
+++ b/test/integration/fixtures/feat-account-padding.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.1.0",
+  "name": "something-with-padding",
+  "instructions": [],
+  "accounts": [
+    {
+      "name": "StructAccountWithPadding",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "count",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": ["u8", 3]
+            },
+            "attrs": ["padding"]
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank",
+    "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+  }
+}

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -38,14 +38,14 @@ async function checkRenderedIx(
     new Map(),
     FORCE_FIXABLE_NEVER
   )
-  verifySyntacticCorrectness(t, ts)
-
-  const analyzed = await analyzeCode(ts)
   if (logCode) {
     console.log(
       `--------- <TypeScript> --------\n${ts}\n--------- </TypeScript> --------`
     )
   }
+  verifySyntacticCorrectness(t, ts)
+
+  const analyzed = await analyzeCode(ts)
   verifyImports(t, analyzed, imports, { logImports })
   if (opts.rxs != null) {
     for (const rx of opts.rxs) {


### PR DESCRIPTION
## Summary

Renders accounts with a padded field in a manner that hides it from the user, but includes it
in de/serialization steps.

## Details

- accounts: exclude padded fields from account struct and args
- account: consider padding field in serialize method
- account: render padding as part of beet type
- test: different account padding scenarios
- fix: account for possibility of empty instructions
- test: adding account padding integration test

## Related PRs

- [shank adding padding attribute](https://github.com/metaplex-foundation/shank/pull/25)

## Example Account with Padding
<details>


```ts
/**
 * This code was GENERATED using the solita package.
 * Please DO NOT EDIT THIS FILE, instead rerun solita to update it or write a wrapper to add functionality.
 *
 * See: https://github.com/metaplex-foundation/solita
 */

import * as beet from '@metaplex-foundation/beet'
import * as web3 from '@solana/web3.js'

/**
 * Arguments used to create {@link StructAccountWithPadding}
 * @category Accounts
 * @category generated
 */
export type StructAccountWithPaddingArgs = {
  count: number
}
/**
 * Holds the data for the {@link StructAccountWithPadding} Account and provides de/serialization
 * functionality for that data
 *
 * @category Accounts
 * @category generated
 */
export class StructAccountWithPadding implements StructAccountWithPaddingArgs {
  private constructor(readonly count: number) {}

  /**
   * Creates a {@link StructAccountWithPadding} instance from the provided args.
   */
  static fromArgs(args: StructAccountWithPaddingArgs) {
    return new StructAccountWithPadding(args.count)
  }

  /**
   * Deserializes the {@link StructAccountWithPadding} from the data of the provided {@link web3.AccountInfo}.
   * @returns a tuple of the account data and the offset up to which the buffer was read to obtain it.
   */
  static fromAccountInfo(
    accountInfo: web3.AccountInfo<Buffer>,
    offset = 0
  ): [StructAccountWithPadding, number] {
    return StructAccountWithPadding.deserialize(accountInfo.data, offset)
  }

  /**
   * Retrieves the account info from the provided address and deserializes
   * the {@link StructAccountWithPadding} from its data.
   *
   * @throws Error if no account info is found at the address or if deserialization fails
   */
  static async fromAccountAddress(
    connection: web3.Connection,
    address: web3.PublicKey
  ): Promise<StructAccountWithPadding> {
    const accountInfo = await connection.getAccountInfo(address)
    if (accountInfo == null) {
      throw new Error(
        `Unable to find StructAccountWithPadding account at ${address}`
      )
    }
    return StructAccountWithPadding.fromAccountInfo(accountInfo, 0)[0]
  }

  /**
   * Deserializes the {@link StructAccountWithPadding} from the provided data Buffer.
   * @returns a tuple of the account data and the offset up to which the buffer was read to obtain it.
   */
  static deserialize(
    buf: Buffer,
    offset = 0
  ): [StructAccountWithPadding, number] {
    return structAccountWithPaddingBeet.deserialize(buf, offset)
  }

  /**
   * Serializes the {@link StructAccountWithPadding} into a Buffer.
   * @returns a tuple of the created Buffer and the offset up to which the buffer was written to store it.
   */
  serialize(): [Buffer, number] {
    return structAccountWithPaddingBeet.serialize({
      padding: Array(3).fill(0),
      ...this,
    })
  }

  /**
   * Returns the byteSize of a {@link Buffer} holding the serialized data of
   * {@link StructAccountWithPadding}
   */
  static get byteSize() {
    return structAccountWithPaddingBeet.byteSize
  }

  /**
   * Fetches the minimum balance needed to exempt an account holding
   * {@link StructAccountWithPadding} data from rent
   *
   * @param connection used to retrieve the rent exemption information
   */
  static async getMinimumBalanceForRentExemption(
    connection: web3.Connection,
    commitment?: web3.Commitment
  ): Promise<number> {
    return connection.getMinimumBalanceForRentExemption(
      StructAccountWithPadding.byteSize,
      commitment
    )
  }

  /**
   * Determines if the provided {@link Buffer} has the correct byte size to
   * hold {@link StructAccountWithPadding} data.
   */
  static hasCorrectByteSize(buf: Buffer, offset = 0) {
    return buf.byteLength - offset === StructAccountWithPadding.byteSize
  }

  /**
   * Returns a readable version of {@link StructAccountWithPadding} properties
   * and can be used to convert to JSON and/or logging
   */
  pretty() {
    return {
      count: this.count,
    }
  }
}

/**
 * @category Accounts
 * @category generated
 */
export const structAccountWithPaddingBeet = new beet.BeetStruct<
  StructAccountWithPadding,
  StructAccountWithPaddingArgs & {
    padding: number[] /* size: 3 */
  }
>(
  [
    ['count', beet.u8],
    ['padding', beet.uniformFixedSizeArray(beet.u8, 3)],
  ],
  StructAccountWithPadding.fromArgs,
  'StructAccountWithPadding'
)
```
</details>