### PR TITLE
feat: override accound keys and program id

### DIFF
--- a/src/known-pubkeys.ts
+++ b/src/known-pubkeys.ts
@@ -79,9 +79,13 @@ export function resolveKnownPubkey(id: string): ResolvedKnownPubkey | null {
   return { ...item, packExportName }
 }
 
-export function renderKnownPubkeyAccess({
-  exp,
-  packExportName,
-}: ResolvedKnownPubkey) {
+export function renderKnownPubkeyAccess(
+  knownPubkey: ResolvedKnownPubkey,
+  programIdPubkey: string
+) {
+  if (isProgramIdKnownPubkey(knownPubkey)) {
+    return programIdPubkey
+  }
+  const { exp, packExportName } = knownPubkey
   return `${packExportName}.${exp}`
 }

--- a/src/known-pubkeys.ts
+++ b/src/known-pubkeys.ts
@@ -1,4 +1,6 @@
 import {
+  PROGRAM_ID_EXPORT_NAME,
+  PROGRAM_ID_PACKAGE,
   SOLANA_SPL_TOKEN_EXPORT_NAME,
   SOLANA_SPL_TOKEN_PACKAGE,
   SOLANA_WEB3_EXPORT_NAME,
@@ -9,9 +11,11 @@ import { UnreachableCaseError } from './utils'
 export type PubkeysPackage =
   | typeof SOLANA_WEB3_PACKAGE
   | typeof SOLANA_SPL_TOKEN_PACKAGE
+  | typeof PROGRAM_ID_PACKAGE
 export type PubkeysPackageExportName =
   | typeof SOLANA_WEB3_EXPORT_NAME
   | typeof SOLANA_SPL_TOKEN_EXPORT_NAME
+  | typeof PROGRAM_ID_EXPORT_NAME
 
 const knownPubkeysMap: Map<
   string,
@@ -30,6 +34,7 @@ const knownPubkeysMap: Map<
     { exp: 'SystemProgram.programId', pack: SOLANA_WEB3_PACKAGE },
   ],
   ['rent', { exp: 'SYSVAR_RENT_PUBKEY', pack: SOLANA_WEB3_PACKAGE }],
+  ['programId', { exp: PROGRAM_ID_EXPORT_NAME, pack: PROGRAM_ID_PACKAGE }],
 ])
 
 function pubkeysPackageExportName(
@@ -40,6 +45,8 @@ function pubkeysPackageExportName(
       return SOLANA_SPL_TOKEN_EXPORT_NAME
     case SOLANA_WEB3_PACKAGE:
       return SOLANA_WEB3_EXPORT_NAME
+    case PROGRAM_ID_PACKAGE:
+      return PROGRAM_ID_EXPORT_NAME
     default:
       throw new UnreachableCaseError(pack)
   }
@@ -53,6 +60,15 @@ export type ResolvedKnownPubkey = {
 
 export function isKnownPubkey(id: string) {
   return knownPubkeysMap.has(id)
+}
+export function isProgramIdPubkey(id: string) {
+  return id == 'programId'
+}
+export function isProgramIdKnownPubkey(knownPubkey: ResolvedKnownPubkey) {
+  return (
+    knownPubkey.exp === PROGRAM_ID_EXPORT_NAME &&
+    knownPubkey.pack === PROGRAM_ID_PACKAGE
+  )
 }
 
 export function resolveKnownPubkey(id: string): ResolvedKnownPubkey | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,3 +269,6 @@ export const BEET_EXPORT_NAME = 'beet'
 export const BEET_SOLANA_EXPORT_NAME = 'beetSolana'
 export const SOLANA_WEB3_EXPORT_NAME = 'web3'
 export const SOLANA_SPL_TOKEN_EXPORT_NAME = 'splToken'
+
+export const PROGRAM_ID_PACKAGE = '<program-id>'
+export const PROGRAM_ID_EXPORT_NAME = '<program-id-export>'

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -184,7 +184,7 @@ test('ix: two accounts and two args', async (t) => {
     t,
     ix,
     [BEET_PACKAGE, BEET_SOLANA_PACKAGE, SOLANA_WEB3_PACKAGE],
-    { logCode: fals }
+    { logCode: false }
   )
 })
 
@@ -278,7 +278,11 @@ test('ix: empty args one system program account', async (t) => {
     args: [],
   }
   await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
-    rxs: [/programId = new web3\.PublicKey\('testprogram'\)/],
+    logCode: false,
+    rxs: [
+      /programId = new web3\.PublicKey\('testprogram'\)/,
+      /pubkey\: accounts\.systemProgram \?\? web3\.SystemProgram\.programId/,
+    ],
     nonrxs: [/pubkey\: accounts\.programId/],
   })
 })
@@ -311,5 +315,38 @@ test('ix: with args one system program account and programId', async (t) => {
       /programId = new web3\.PublicKey\('testprogram'\)/,
       /pubkey\: accounts\.programId/,
     ],
+  })
+})
+
+test('ix: empty args one system program account + one optional rent account', async (t) => {
+  const ix = {
+    name: 'empyArgsWithSystemProgram',
+    accounts: [
+      {
+        name: 'authority',
+        isMut: false,
+        isSigner: true,
+      },
+      {
+        name: 'systemProgram',
+        isMut: false,
+        isSigner: false,
+      },
+      {
+        name: 'rent',
+        isMut: false,
+        isSigner: false,
+        optional: true,
+      },
+    ],
+    args: [],
+  }
+  await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
+    logCode: false,
+    rxs: [
+      /programId = new web3\.PublicKey\('testprogram'\)/,
+      /pubkey\: accounts.rent,/,
+    ],
+    nonrxs: [/pubkey\: accounts\.programId/],
   })
 })


### PR DESCRIPTION
# Summary

This PR adds the ability for users to do the following:

- provide a `programId`, if not provided it defaults to the `programId` provided to solita
  during code generation
- provide overrides for _known_ account ids like `tokenProgram`, if not provided it defaults to
  the keys provided by the respective libraries

## Example

_Auction Houes_ `buy` instruction serves as a shortened example of what is generated now:

### Accounts Type

```ts
/**
 * Accounts required by the _buy_ instruction
 *
 * @property [**signer**] wallet
 * @property [_writable_] paymentAccount
 * @property [] transferAuthority
 * @property [] treasuryMint
 * @property [] tokenAccount
 * @property [] metadata
 * @property [_writable_] escrowPaymentAccount
 * @property [] authority
 * @property [] auctionHouse
 * @property [_writable_] auctionHouseFeeAccount
 * @property [_writable_] buyerTradeState
 * @category Instructions
 * @category Buy
 * @category generated
 */
export type BuyInstructionAccounts = {
  wallet: web3.PublicKey
  paymentAccount: web3.PublicKey
  transferAuthority: web3.PublicKey
  treasuryMint: web3.PublicKey
  tokenAccount: web3.PublicKey
  metadata: web3.PublicKey
  escrowPaymentAccount: web3.PublicKey
  authority: web3.PublicKey
  auctionHouse: web3.PublicKey
  auctionHouseFeeAccount: web3.PublicKey
  buyerTradeState: web3.PublicKey
  tokenProgram?: web3.PublicKey
  systemProgram?: web3.PublicKey
  rent?: web3.PublicKey
}
```

NOTE: that the optional accounts are not included in the comments as overriding them is a
_hidden_ feature.

### Known Account Resolution

```ts
  const keys: web3.AccountMeta[] = [
    {
      pubkey: accounts.wallet,
      isWritable: false,
      isSigner: true,
    },
    [ .. many more .. ]
    {
      pubkey: accounts.tokenProgram ?? splToken.TOKEN_PROGRAM_ID,
      isWritable: false,
      isSigner: false,
    },
    {
      pubkey: accounts.systemProgram ?? web3.SystemProgram.programId,
      isWritable: false,
      isSigner: false,
    },
    {
      pubkey: accounts.rent ?? web3.SYSVAR_RENT_PUBKEY,
      isWritable: false,
      isSigner: false,
    },
  ]
```

### Program ID

```ts
/**
 * Creates a _Buy_ instruction.
 *
 * @param accounts that will be accessed while the instruction is processed
 * @param args to provide as instruction data to the program
 *
 * @category Instructions
 * @category Buy
 * @category generated
 */
export function createBuyInstruction(
  accounts: BuyInstructionAccounts,
  args: BuyInstructionArgs,
  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk')
) {

  // [ .. ]

  const ix = new web3.TransactionInstruction({
    programId,
    keys,
    data,
  })

  return ix
}
```

NOTE: `programId` is not listed in the docs as overriding it is a _hidden feature_ as well.

FIXES: #44