### PR TITLE
feat: expose beet-solana gpa builder on account struct

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.3.0",
-    "@metaplex-foundation/beet-solana": "^0.2.0",
+    "@metaplex-foundation/beet": "^0.4.0",
+    "@metaplex-foundation/beet-solana": "^0.3.0",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.36.0",
     "camelcase": "^6.2.1",

--- a/src/solita.ts
+++ b/src/solita.ts
@@ -245,6 +245,7 @@ export class Solita {
         this.typeAliases,
         this.serializers,
         forceFixable,
+        programId,
         this.resolveFieldType,
         this.accountsHaveImplicitDiscriminator
       )

--- a/test/render-accounts.ts
+++ b/test/render-accounts.ts
@@ -14,6 +14,7 @@ import {
   verifyImports,
   verifySyntacticCorrectness,
 } from './utils/verify-code'
+const PROGRAM_ID = 'testprogram'
 
 const DIAGNOSTIC_ON = false
 
@@ -46,6 +47,7 @@ async function checkRenderedAccount(
     new Map(),
     serializers,
     FORCE_FIXABLE_NEVER,
+    PROGRAM_ID,
     (_: string) => null,
     opts.hasImplicitDiscriminator ?? true
   )
@@ -239,16 +241,21 @@ test('accounts: one account with two fields, one has padding attr', async (t) =>
     },
   }
 
-  await checkRenderedAccount(t, account, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
-    rxs: [
-      /readonly count\: number/,
-      /count\: this\.count/,
-      /args\.count/,
-      /'padding', beet\.uniformFixedSizeArray\(beet\.u8, 3\)/,
-      /padding\: Array\(3\).fill\(0\),/,
-    ],
-    nonrxs: [/readonly padding/, /padding\: this\.padding/, /args\.padding/],
-  })
+  await checkRenderedAccount(
+    t,
+    account,
+    [BEET_PACKAGE, BEET_SOLANA_PACKAGE, SOLANA_WEB3_PACKAGE],
+    {
+      rxs: [
+        /readonly count\: number/,
+        /count\: this\.count/,
+        /args\.count/,
+        /'padding', beet\.uniformFixedSizeArray\(beet\.u8, 3\)/,
+        /padding\: Array\(3\).fill\(0\),/,
+      ],
+      nonrxs: [/readonly padding/, /padding\: this\.padding/, /args\.padding/],
+    }
+  )
   t.end()
 })
 
@@ -273,17 +280,22 @@ test('accounts: one account with two fields without implicit discriminator, one 
     },
   }
 
-  await checkRenderedAccount(t, account, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
-    rxs: [
-      /readonly count\: number/,
-      /args\.count/,
-      /count\: this\.count/,
-      /'padding', beet\.uniformFixedSizeArray\(beet\.u8, 3\)/,
-      /padding\: Array\(3\).fill\(0\),/,
-    ],
-    nonrxs: [/readonly padding/, /padding\: this\.padding/, /args\.padding/],
-    hasImplicitDiscriminator: false,
-  })
+  await checkRenderedAccount(
+    t,
+    account,
+    [BEET_PACKAGE, BEET_SOLANA_PACKAGE, SOLANA_WEB3_PACKAGE],
+    {
+      rxs: [
+        /readonly count\: number/,
+        /args\.count/,
+        /count\: this\.count/,
+        /'padding', beet\.uniformFixedSizeArray\(beet\.u8, 3\)/,
+        /padding\: Array\(3\).fill\(0\),/,
+      ],
+      nonrxs: [/readonly padding/, /padding\: this\.padding/, /args\.padding/],
+      hasImplicitDiscriminator: false,
+    }
+  )
   t.end()
 })
 
@@ -312,19 +324,24 @@ test('accounts: one account with three fields, middle one has padding attr', asy
     },
   }
 
-  await checkRenderedAccount(t, account, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
-    rxs: [
-      /readonly count\: number/,
-      /readonly largerCount\: beet.bignum/,
-      /args\.count/,
-      /args\.largerCount/,
-      /count\: this\.count/,
-      /largerCount\: /,
-      /'padding', beet\.uniformFixedSizeArray\(beet\.u8, 5\)/,
-      /padding\: Array\(5\).fill\(0\),/,
-    ],
-    nonrxs: [/readonly padding/, /padding\: this\.padding/, /args\.padding/],
-  })
+  await checkRenderedAccount(
+    t,
+    account,
+    [BEET_PACKAGE, BEET_SOLANA_PACKAGE, SOLANA_WEB3_PACKAGE],
+    {
+      rxs: [
+        /readonly count\: number/,
+        /readonly largerCount\: beet.bignum/,
+        /args\.count/,
+        /args\.largerCount/,
+        /count\: this\.count/,
+        /largerCount\: /,
+        /'padding', beet\.uniformFixedSizeArray\(beet\.u8, 5\)/,
+        /padding\: Array\(5\).fill\(0\),/,
+      ],
+      nonrxs: [/readonly padding/, /padding\: this\.padding/, /args\.padding/],
+    }
+  )
   t.end()
 })
 
@@ -353,20 +370,25 @@ test('accounts: one account with three fields, middle one has padding attr witho
     },
   }
 
-  await checkRenderedAccount(t, account, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
-    logCode: true,
-    rxs: [
-      /readonly count\: number/,
-      /readonly largerCount\: beet.bignum/,
-      /args\.count/,
-      /args\.largerCount/,
-      /count\: this\.count/,
-      /largerCount\: /,
-      /'padding', beet\.uniformFixedSizeArray\(beet\.u8, 5\)/,
-      /padding\: Array\(5\).fill\(0\),/,
-    ],
-    nonrxs: [/readonly padding/, /padding\: this\.padding/, /args\.padding/],
-    hasImplicitDiscriminator: false,
-  })
+  await checkRenderedAccount(
+    t,
+    account,
+    [BEET_PACKAGE, BEET_SOLANA_PACKAGE, SOLANA_WEB3_PACKAGE],
+    {
+      logCode: false,
+      rxs: [
+        /readonly count\: number/,
+        /readonly largerCount\: beet.bignum/,
+        /args\.count/,
+        /args\.largerCount/,
+        /count\: this\.count/,
+        /largerCount\: /,
+        /'padding', beet\.uniformFixedSizeArray\(beet\.u8, 5\)/,
+        /padding\: Array\(5\).fill\(0\),/,
+      ],
+      nonrxs: [/readonly padding/, /padding\: this\.padding/, /args\.padding/],
+      hasImplicitDiscriminator: false,
+    }
+  )
   t.end()
 })


### PR DESCRIPTION
## Summary

Relying on the [recent GPA beet-solana
feature](https://github.com/metaplex-foundation/beet/pull/36), solita now generates a method on
each account struct to obtain a GPA builder for it.

## Example

The below method is added to the `AuctionHouse` account.

```ts
export class AuctionHouse implements AuctionHouseArgs {
  // [ .. ]

  /**
   * Provides a {@link web3.Connection.getProgramAccounts} config builder,
   * to fetch accounts matching filters that can be specified on that builder.
   *
   * @param programId - the program that owns the accounts we are filtering
   */
  static gpaBuilder(
    programId: web3.PublicKey = new web3.PublicKey(
      'hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk'
    )
  ) {
    return beetSolana.GpaBuilder.fromStruct(programId, auctionHouseBeet)
  }
  // [ .. ]
}
```

## Caveats

- requires latest `beet: 0.4.0` and `beet-solana: 0.3.0` to be used in the project whose
  generated code includes that feature
