### PR TITLE
feat: exporting account providers

### DIFF
--- a/src/render-account-providers.ts
+++ b/src/render-account-providers.ts
@@ -1,0 +1,40 @@
+import { IdlAccount } from './types'
+
+class AccountProvidersRenderer {
+  private readonly upperCamelCaseAccountNames: string[]
+  constructor(accounts: IdlAccount[]) {
+    this.upperCamelCaseAccountNames = accounts.map((account) =>
+      account.name.charAt(0).toUpperCase().concat(account.name.slice(1))
+    )
+  }
+
+  _renderImports() {
+    return this.upperCamelCaseAccountNames
+      .map((account) => `import { ${account} } from './${account}'`)
+      .join('\n')
+  }
+
+  _renderProviders() {
+    return `export const accountProviders = { ${this.upperCamelCaseAccountNames.join(
+      ', '
+    )} }`
+  }
+
+  render() {
+    if (this.upperCamelCaseAccountNames.length === 0) return ''
+    return `
+${this._renderImports()}
+
+${this._renderProviders()}
+`.trim()
+  }
+}
+
+/*
+ * Renders imports of all accounts and re-export as account providers assuming
+ * that this code will live in a module located in the same folder as the
+ * account modules.
+ */
+export function renderAccountProviders(accounts?: IdlAccount[]) {
+  return new AccountProvidersRenderer(accounts ?? []).render()
+}

--- a/src/solita.ts
+++ b/src/solita.ts
@@ -31,6 +31,7 @@ import {
 import { format, Options } from 'prettier'
 import { Paths } from './paths'
 import { CustomSerializers } from './serializers'
+import { renderAccountProviders } from './render-account-providers'
 
 export * from './types'
 
@@ -346,9 +347,11 @@ export class Solita {
       await fs.writeFile(this.paths.accountFile(name), code, 'utf8')
     }
     logDebug('Writing index.ts exporting all accounts')
+    const accountProvidersCode = renderAccountProviders(this.idl.accounts)
     const indexCode = this.renderImportIndex(
       Object.keys(accounts).sort(),
-      'accounts'
+      'accounts',
+      accountProvidersCode
     )
     await fs.writeFile(this.paths.accountFile('index'), indexCode, 'utf8')
   }
@@ -430,8 +433,15 @@ ${programIdConsts}
     await fs.writeFile(path.join(this.paths.root, `index.ts`), code, 'utf8')
   }
 
-  private renderImportIndex(modules: string[], label: string) {
+  private renderImportIndex(
+    modules: string[],
+    label: string,
+    extraContent?: string
+  ) {
     let code = modules.map((x) => `export * from './${x}';`).join('\n')
+    if (extraContent != null) {
+      code += `\n\n${extraContent}`
+    }
     if (this.formatCode) {
       try {
         code = format(code, this.formatOpts)

--- a/test/render-account-provider.ts
+++ b/test/render-account-provider.ts
@@ -1,0 +1,46 @@
+import test from 'tape'
+import { IdlAccount } from '../src/solita'
+import { renderAccountProviders } from '../src/render-account-providers'
+
+function accountNamed(accName: string): IdlAccount {
+  return {
+    name: accName,
+    type: {
+      kind: 'struct',
+      fields: [],
+    },
+  }
+}
+
+function includesAccount(t: test.Test, code: string, accName: string) {
+  const lines = code.split('\n')
+  const exports = lines.pop()!
+  const imports = lines.join('\n')
+  const importNeedle = `import { ${accName}`
+  t.ok(imports.includes(importNeedle), `imports ${accName}`)
+  t.ok(exports.includes(accName), `exports ${accName}`)
+}
+
+test('accountProviders: for zero accounts', (t) => {
+  const code = renderAccountProviders([])
+  t.equal(code.length, 0, 'renders no code')
+  t.end()
+})
+
+test('accountProviders: for one account', (t) => {
+  const code = renderAccountProviders([accountNamed('collectionAccount')])
+  includesAccount(t, code, 'CollectionAccount')
+  t.end()
+})
+
+test('accountProviders: for three accounts', (t) => {
+  const code = renderAccountProviders([
+    accountNamed('collectionAccount'),
+    accountNamed('data'),
+    accountNamed('solitaMaker'),
+  ])
+  includesAccount(t, code, 'CollectionAccount')
+  includesAccount(t, code, 'Data')
+  includesAccount(t, code, 'SolitaMaker')
+  t.end()
+})


### PR DESCRIPTION
## Summary

Tools like [amman](https://github.com/metaplex-foundation/amman) depend on deserializing
accounts in order to show their data on the terminal or a UI.

Therefore solita now exports `accountProviders` similar to the below (example from
mpl_token_metadata):

```ts
import { UseAuthorityRecord } from './UseAuthorityRecord'
import { CollectionAuthorityRecord } from './CollectionAuthorityRecord'
import { Metadata } from './Metadata'
import { MasterEditionV2 } from './MasterEditionV2'
import { MasterEditionV1 } from './MasterEditionV1'
import { Edition } from './Edition'
import { ReservationListV2 } from './ReservationListV2'
import { ReservationListV1 } from './ReservationListV1'
import { EditionMarker } from './EditionMarker'

export const accountProviders = {
  UseAuthorityRecord,
  CollectionAuthorityRecord,
  Metadata,
  MasterEditionV2,
  MasterEditionV1,
  Edition,
  ReservationListV2,
  ReservationListV1,
  EditionMarker,
}
```

The tool in question can then import/combine them as follow:

```js
const {
  accountProviders: candyProviders,
  PROGRAM_ADDRESS: CandyAddress,
} = require("@metaplex-foundation/mpl-candy-machine");
const {
  accountProviders: tokenMetadataProviders,
  PROGRAM_ADDRESS: TokenMetadataAddress,
} = require("@metaplex-foundation/mpl-token-metadata");

const accountProviders = {
  [CandyAddress]: candyProviders,
  [TokenMetadataAddress]: tokenMetadataProviders,
};

```

This allows such tool to encounter the correct de/serializer by applying the ones for the providers of the program that owns a particular account.
The fitting account provider can be determined by comparing account size (if the account is fixed size) or just attempting to deserialize an account until it succeeds.

FIXES: #67

## Details

- accounts index file imports all account classes and re-exports them as
  `accountProviders`
- since the main generated index file has `export * from './accounts'`
  they are exported as part of the module SDK
