### PR TITLE
feat: render tuples

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.4.0",
+    "@metaplex-foundation/beet": "^0.5.0",
     "@metaplex-foundation/beet-solana": "^0.3.0",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.36.0",

--- a/src/render-data-enum.ts
+++ b/src/render-data-enum.ts
@@ -17,14 +17,7 @@ export function renderTypeDataEnumBeet(args: {
   const renderedVariants = dataEnum.variants.map((variant) => {
     const tm = typeMapper.clone()
     const beet = renderVariant(tm, enumRecordName, variant)
-    for (const used of tm.serdePackagesUsed) {
-      typeMapper.serdePackagesUsed.add(used)
-    }
-    for (const [key, val] of tm.scalarEnumsUsed) {
-      typeMapper.scalarEnumsUsed.set(key, val)
-    }
-    typeMapper.usedFixableSerde =
-      typeMapper.usedFixableSerde || tm.usedFixableSerde
+    typeMapper.syncUp(tm)
     return { beet, usedFixableSerde: tm.usedFixableSerde }
   })
 

--- a/src/type-mapper.ts
+++ b/src/type-mapper.ts
@@ -329,10 +329,10 @@ export class TypeMapper {
     const inners = innerSerdes.join(', ')
 
     if (innerMapper.usedFixableSerde) {
-      const tuple = this.primaryTypeMap['Tuple']
+      const tuple = this.primaryTypeMap.Tuple
       return `${exp}.${tuple.beet}([${inners}])`
     } else {
-      const fixedTuple = this.primaryTypeMap['FixedSizeTuple']
+      const fixedTuple = this.primaryTypeMap.FixedSizeTuple
       return `${exp}.${fixedTuple.beet}([${inners}])`
     }
   }

--- a/src/type-mapper.ts
+++ b/src/type-mapper.ts
@@ -179,6 +179,9 @@ export class TypeMapper {
   }
 
   private mapEnumType(ty: IdlTypeEnum, name: string) {
+    if (name === NO_NAME_PROVIDED && ty.name != null) {
+      name = ty.name
+    }
     assert.notEqual(
       name,
       NO_NAME_PROVIDED,
@@ -296,6 +299,9 @@ export class TypeMapper {
   }
 
   private mapEnumSerde(ty: IdlTypeEnum, name: string) {
+    if (name === NO_NAME_PROVIDED && ty.name != null) {
+      name = ty.name
+    }
     assert.notEqual(
       name,
       NO_NAME_PROVIDED,

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type IdlType =
   | IdlTypeArray
   | IdlTypeEnum
   | IdlTypeDataEnum
+  | IdlTypeTuple
 
 // User defined type.
 export type IdlTypeDefined = {
@@ -88,6 +89,10 @@ export type IdlTypeScalarEnum = {
 export type IdlTypeDataEnum = {
   kind: 'enum'
   variants: IdlDataEnumVariant[]
+}
+
+export type IdlTypeTuple = {
+  tuple: IdlType[]
 }
 
 export type IdlDefinedType = {
@@ -162,12 +167,10 @@ export type ShankMetadata = Idl['metadata'] & { origin: 'shank' }
 // De/Serializers + Extensions
 // -----------------
 export type PrimitiveTypeKey = BeetTypeMapKey | BeetSolanaTypeMapKey
-export type PrimaryTypeMap = Record<
-  PrimitiveTypeKey,
-  SupportedTypeDefinition & {
-    beet: BeetExports | BeetSolanaExports
-  }
->
+export type PrimaryType = SupportedTypeDefinition & {
+  beet: BeetExports | BeetSolanaExports
+}
+export type PrimaryTypeMap = Record<PrimitiveTypeKey, PrimaryType>
 export type ProcessedSerde = {
   name: string
   sourcePack: SerdePackage
@@ -230,6 +233,10 @@ export function isIdlTypeScalarEnum(
   ty: IdlType | IdlDefinedType | IdlTypeEnum
 ): ty is IdlTypeScalarEnum {
   return isIdlTypeEnum(ty) && !isIdlTypeDataEnum(ty)
+}
+
+export function isIdlTypeTuple(ty: IdlType): ty is IdlTypeTuple {
+  return (ty as IdlTypeTuple).tuple != null
 }
 
 export function isIdlDefinedType(

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,11 +83,13 @@ export type IdlDataEnumVariant = {
 export type IdlTypeEnum = IdlTypeScalarEnum | IdlTypeDataEnum
 export type IdlTypeScalarEnum = {
   kind: 'enum'
+  name?: string
   variants: IdlEnumVariant[]
 }
 
 export type IdlTypeDataEnum = {
   kind: 'enum'
+  name?: string
   variants: IdlDataEnumVariant[]
 }
 

--- a/test/integration/feat-tuples.ts
+++ b/test/integration/feat-tuples.ts
@@ -1,0 +1,27 @@
+import { Idl, Solita } from '../../src/solita'
+import test from 'tape'
+import path from 'path'
+import {
+  verifySyntacticCorrectnessForGeneratedDir,
+  verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
+} from '../utils/verify-code'
+import json from './fixtures/feat-tuples.json'
+import { sync as rmrf } from 'rimraf'
+
+const outputDir = path.join(__dirname, 'output', 'feat-tuples')
+const generatedSDKDir = path.join(outputDir, 'generated')
+
+test('renders type correct SDK for feat-tuples', async (t) => {
+  rmrf(outputDir)
+  const idl = json as Idl
+  idl.metadata = {
+    ...idl.metadata,
+    address: 'A1BvUFMKzoubnHEFhvhJxXyTfEN6r2DqCZxJFF9hfH3x',
+  }
+  const gen = new Solita(idl, { formatCode: true })
+  await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
+  await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
+  await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
+})

--- a/test/integration/fixtures/feat-tuples.json
+++ b/test/integration/fixtures/feat-tuples.json
@@ -1,0 +1,59 @@
+{
+  "version": "0.1.0",
+  "name": "feat_tuples",
+  "instructions": [],
+  "types": [
+    {
+      "name": "PackConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accountType",
+            "type": {
+              "defined": "AccountType"
+            }
+          },
+          {
+            "name": "weights",
+            "type": {
+              "vec": {
+                "tuple": ["u32", "u32", "u32"]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AccountType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Uninitialized"
+          },
+          {
+            "name": "PackSet"
+          },
+          {
+            "name": "PackCard"
+          },
+          {
+            "name": "PackVoucher"
+          },
+          {
+            "name": "ProvingProcess"
+          },
+          {
+            "name": "PackConfig"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank",
+    "address": "packFeFNZzMfD9aVWL7QbGz1WcU7R9zpf6pvNsw2BLu"
+  }
+}

--- a/test/utils/helpers.ts
+++ b/test/utils/helpers.ts
@@ -1,0 +1,9 @@
+import { inspect } from 'util'
+
+export function deepInspect(obj: any) {
+  return inspect(obj, { depth: 15, colors: true, getters: true })
+}
+
+export function deepLog(obj: any) {
+  console.log(deepInspect(obj))
+}


### PR DESCRIPTION
## Summary

Renders tuples (indicated via `tuple` in the IDL).

This supports tuples nested inside other types as in the below example as well as tuples whose
elements themselves are composites.

A part of nft-packs IDL was included to serve as a smoke-test and more detailed tests were
added to the typemapper.

### Example

Rendering `Vec<u32, u32, u32>`

```ts
export type PackConfig = {
  weights: [number, number, number][]
}

export const packConfigBeet = new beet.FixableBeetArgsStruct<PackConfig>(
  [
    [
      'weights',
      beet.array(beet.fixedSizeTuple([beet.u32, beet.u32, beet.u32])),
    ],
  ],
  'PackConfig'
)
```
