### PR TITLE
feat: fix anchor maps via transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "rimraf": "^3.0.2",
     "spok": "^1.4.3",
     "tape": "^5.3.2",
-    "typedoc": "^0.22.10",
-    "typescript": "^4.5.2"
+    "typedoc": "^0.23.11",
+    "typescript": "^4.8.2"
   }
 }

--- a/src/render-data-enum.ts
+++ b/src/render-data-enum.ts
@@ -3,9 +3,12 @@ import { TypeMapper } from './type-mapper'
 import {
   BEET_EXPORT_NAME,
   IdlDataEnumVariant,
+  IdlType,
   IdlTypeDataEnum,
+  IdlTypeTuple,
   isDataEnumVariant,
   isDataEnumVariantWithNamedFields,
+  isIdlFieldType,
 } from './types'
 
 /**
@@ -75,7 +78,8 @@ function renderVariant(
     return beet
   } else if (isDataEnumVariant(variant)) {
     // Variant with unnamed fields is represented as a tuple
-    const fieldDecls = typeMapper.mapSerde({ tuple: variant.fields })
+    const tuple: IdlTypeTuple = { tuple: variant.fields as IdlType[] }
+    const fieldDecls = typeMapper.mapSerde(tuple)
     const beetArgsStructType = typeMapper.usedFixableSerde
       ? 'FixableBeetArgsStruct'
       : 'BeetArgsStruct'
@@ -112,7 +116,8 @@ export function renderDataEnumRecord(
       return `  ${variant.name}: { ${fields.join(', ')} }`
     } else if (isDataEnumVariant(variant)) {
       fields = variant.fields.map((type, idx) => {
-        return typeMapper.map(type, `${variant.name}[${idx}]`)
+        const ty = isIdlFieldType(type) ? type.type : type
+        return typeMapper.map(ty, `${variant.name}[${idx}]`)
       })
       return `  ${variant.name}: { fields: [ ${fields.join(', ')} ] }`
     } else {

--- a/src/transform-type.ts
+++ b/src/transform-type.ts
@@ -1,0 +1,82 @@
+import {
+  BeetTypeMapKey,
+  numbersTypeMap,
+  NumbersTypeMapKey,
+} from '@metaplex-foundation/beet'
+import {
+  IdlFieldsType,
+  IdlDefinedTypeDefinition,
+  IdlType,
+  isFieldsType,
+  isIdlTypeDefined,
+  IdlTypeHashMap,
+  IdlTypeBTreeMap,
+} from './types'
+
+const mapRx = /^(Hash|BTree)Map<([^,\s]+)\s?,([^>\s]+)\s?>/
+
+/**
+ * When anchor doesn't understand a type it just assumes it is a user defined one.
+ * This includes HashMaps and BTreeMaps. However it doesn't check if that type
+ * is actually defined somewhere.
+ * Thus we end up with invalid types here like `HashMap<String,DataItem>` which
+ * is basically just the type definition copied from the Rust code.
+ *
+ * This function attempts to fix this. At this point only top level struct
+ * fields are supported.
+ *
+ * Whenever more cases of incorrect types are encountered this transformer needs
+ * to be updated to handle them.
+ */
+export function transformDefinition(def: IdlDefinedTypeDefinition) {
+  const ty = def.type
+  if (isFieldsType(ty)) {
+    def.type = transformFields(ty)
+  }
+  return def
+}
+
+function transformType(ty: IdlType) {
+  if (isIdlTypeDefined(ty)) {
+    const match = ty.defined.match(mapRx)
+    if (match == null) return ty
+
+    const [_, mapTy, inner1, inner2] = match
+
+    const innerTy1 = resolveType(inner1)
+    const innerTy2 = resolveType(inner2)
+
+    if (mapTy === 'Hash') {
+      const map: IdlTypeHashMap = { hashMap: [innerTy1, innerTy2] }
+      return map
+    } else {
+      const map: IdlTypeBTreeMap = { bTreeMap: [innerTy1, innerTy2] }
+      return map
+    }
+  }
+  return ty
+}
+
+function resolveType(ts: string): IdlType {
+  const tslower = ts.toLowerCase()
+  switch (tslower) {
+    case 'string':
+      return 'string' as BeetTypeMapKey
+    case 'publicKey':
+      return 'publicKey'
+    default:
+      if (numbersTypeMap[tslower as NumbersTypeMapKey] != null) {
+        return tslower as NumbersTypeMapKey
+      }
+      // For now only supporting primitive key/val types when fixing anchor types
+      // if the above doesn't match, then we assume it is a user defined type
+      return { defined: ts }
+  }
+}
+
+function transformFields(ty: IdlFieldsType) {
+  for (const f of ty.fields) {
+    f.type = transformType(f.type)
+  }
+  return ty
+}

--- a/src/transform-type.ts
+++ b/src/transform-type.ts
@@ -12,6 +12,7 @@ import {
   IdlTypeHashMap,
   IdlTypeBTreeMap,
 } from './types'
+import { logWarn } from './utils'
 
 const mapRx = /^(Hash|BTree)Map<([^,\s]+)\s?,([^>\s]+)\s?>/
 
@@ -41,6 +42,10 @@ function transformType(ty: IdlType) {
     const match = ty.defined.match(mapRx)
     if (match == null) return ty
 
+    logWarn(
+      `Discovered an incorrectly defined map '${ty.defined}' as part of the IDL.
+Solita will attempt to fix this type, but you should inform the authors of the tool that generated the IDL about this issue`
+    )
     const [_, mapTy, inner1, inner2] = match
 
     const innerTy1 = resolveType(inner1)

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@
 import {
   BeetExports,
   BeetTypeMapKey,
+  numbersTypeMap,
+  NumbersTypeMapKey,
   SupportedTypeDefinition,
 } from '@metaplex-foundation/beet'
 import {
@@ -369,6 +371,31 @@ export function isIdlInstructionAccountWithDesc(
 // -----------------
 export function hasPaddingAttr(field: IdlField): boolean {
   return field.attrs != null && field.attrs.includes(IDL_FIELD_ATTR_PADDING)
+}
+
+// -----------------
+// Primitivies
+// -----------------
+// NOTE: part of this could be moved to beet
+export type PrimitiveType = Exclude<NumbersTypeMapKey, typeof BIGNUM>
+export const BIGNUM = [
+  'u64',
+  'u128',
+  'u256',
+  'u512',
+  'i64',
+  'i128',
+  'i256',
+  'i512',
+] as const
+export type Bignum = typeof BIGNUM[number]
+export function isNumberLikeType(ty: IdlType): ty is NumbersTypeMapKey {
+  return (
+    typeof ty === 'string' && numbersTypeMap[ty as NumbersTypeMapKey] != null
+  )
+}
+export function isPrimitiveType(ty: IdlType): ty is PrimitiveType {
+  return isNumberLikeType(ty) && !BIGNUM.includes(ty as Bignum)
 }
 
 // -----------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,14 +126,14 @@ export type IdlTypeBTreeMap = {
 // -----------------
 // Defined
 // -----------------
-export type IdlDefinedType = {
+export type IdlFieldsType = {
   kind: 'struct' | 'enum'
   fields: IdlField[]
 }
 
 export type IdlDefinedTypeDefinition = {
   name: string
-  type: IdlDefinedType | IdlTypeEnum | IdlTypeDataEnum
+  type: IdlFieldsType | IdlTypeEnum | IdlTypeDataEnum
 }
 
 // -----------------
@@ -250,7 +250,7 @@ export function isIdlTypeDefined(ty: IdlType): ty is IdlTypeDefined {
 }
 
 export function isIdlTypeEnum(
-  ty: IdlType | IdlDefinedType | IdlTypeEnum
+  ty: IdlType | IdlFieldsType | IdlTypeEnum
 ): ty is IdlTypeEnum {
   return (ty as IdlTypeEnum).variants != null
 }
@@ -259,7 +259,7 @@ export function isIdlTypeEnum(
 // Enums
 // -----------------
 export function isIdlTypeDataEnum(
-  ty: IdlType | IdlDefinedType | IdlTypeEnum
+  ty: IdlType | IdlFieldsType | IdlTypeEnum
 ): ty is IdlTypeDataEnum {
   const dataEnum = ty as IdlTypeDataEnum
   return (
@@ -272,7 +272,7 @@ export function isIdlTypeDataEnum(
 }
 
 export function isIdlTypeScalarEnum(
-  ty: IdlType | IdlDefinedType | IdlTypeEnum
+  ty: IdlType | IdlFieldsType | IdlTypeEnum
 ): ty is IdlTypeScalarEnum {
   return isIdlTypeEnum(ty) && !isIdlTypeDataEnum(ty)
 }
@@ -306,10 +306,16 @@ export function isDataEnumVariantWithUnnamedFields(
   return !isDataEnumVariantWithNamedFields(ty)
 }
 
+// -----------------
+// Tuple
+// -----------------
 export function isIdlTypeTuple(ty: IdlType): ty is IdlTypeTuple {
   return (ty as IdlTypeTuple).tuple != null
 }
 
+// -----------------
+// Maps
+// -----------------
 export function isIdlTypeHashMap(ty: IdlType): ty is IdlTypeHashMap {
   return (ty as IdlTypeHashMap).hashMap != null
 }
@@ -322,12 +328,26 @@ export function isIdlTypeMap(ty: IdlType): ty is IdlTypeMap {
   return isIdlTypeHashMap(ty) || isIdlTypeBTreeMap(ty)
 }
 
-export function isIdlDefinedType(
-  ty: IdlType | IdlDefinedType
-): ty is IdlDefinedType {
-  return (ty as IdlDefinedType).fields != null
+export function isIdlFieldsType(
+  ty: IdlType | IdlFieldsType
+): ty is IdlFieldsType {
+  return (ty as IdlFieldsType).fields != null
 }
 
+// -----------------
+// Struct/Enum
+// -----------------
+
+export function isFieldsType(
+  ty: IdlFieldsType | IdlTypeEnum | IdlTypeDataEnum
+): ty is IdlFieldsType {
+  const dety = ty as IdlFieldsType
+  return dety.kind === 'enum' || dety.kind === 'struct'
+}
+
+// -----------------
+// Idl
+// -----------------
 export function isShankIdl(ty: Idl): ty is ShankIdl {
   return (ty as ShankIdl).metadata?.origin === 'shank'
 }
@@ -344,6 +364,9 @@ export function isIdlInstructionAccountWithDesc(
   return typeof (ty as IdlInstructionAccountWithDesc).desc === 'string'
 }
 
+// -----------------
+// Padding
+// -----------------
 export function hasPaddingAttr(field: IdlField): boolean {
   return field.attrs != null && field.attrs.includes(IDL_FIELD_ATTR_PADDING)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -330,10 +330,18 @@ export function isIdlTypeMap(ty: IdlType): ty is IdlTypeMap {
   return isIdlTypeHashMap(ty) || isIdlTypeBTreeMap(ty)
 }
 
+// -----------------
+// Fields
+// -----------------
 export function isIdlFieldsType(
   ty: IdlType | IdlFieldsType
 ): ty is IdlFieldsType {
   return (ty as IdlFieldsType).fields != null
+}
+
+export function isIdlFieldType(ty: IdlType | IdlField): ty is IdlField {
+  const fieldTy = ty as IdlField
+  return fieldTy.type != null && fieldTy.name != null
 }
 
 // -----------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,7 +344,10 @@ export function isFieldsType(
   ty: IdlFieldsType | IdlTypeEnum | IdlTypeDataEnum
 ): ty is IdlFieldsType {
   const dety = ty as IdlFieldsType
-  return dety.kind === 'enum' || dety.kind === 'struct'
+  return (
+    (dety.kind === 'enum' || dety.kind === 'struct') &&
+    Array.isArray(dety.fields)
+  )
 }
 
 // -----------------

--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -1,6 +1,7 @@
 import debug from 'debug'
 
 export const logErrorDebug = debug('solita:error')
+export const logWarnDebug = debug('solita:warn')
 export const logInfoDebug = debug('solita:info')
 export const logDebug = debug('solita:debug')
 export const logTrace = debug('solita:trace')
@@ -8,6 +9,10 @@ export const logTrace = debug('solita:trace')
 export const logError = logErrorDebug.enabled
   ? logErrorDebug
   : console.error.bind(console)
+
+export const logWarn = logErrorDebug.enabled
+  ? logWarnDebug
+  : console.warn.bind(console)
 
 export const logInfo = logInfoDebug.enabled
   ? logInfoDebug

--- a/test/integration/feat-fix-anchor-maps.ts
+++ b/test/integration/feat-fix-anchor-maps.ts
@@ -1,0 +1,27 @@
+import { Idl, Solita } from '../../src/solita'
+import test from 'tape'
+import path from 'path'
+import {
+  verifySyntacticCorrectnessForGeneratedDir,
+  verifyTopLevelScriptForGeneratedDir,
+  verifyWithTypescriptCompiler,
+} from '../utils/verify-code'
+import json from './fixtures/feat-fix-anchor-maps.json'
+import { sync as rmrf } from 'rimraf'
+
+const outputDir = path.join(__dirname, 'output', 'feat-fix-anchor-maps')
+const generatedSDKDir = path.join(outputDir, 'generated')
+
+test('renders type correct SDK for feat-fix-anchor-maps', async (t) => {
+  rmrf(outputDir)
+  const idl = json as Idl
+  idl.metadata = {
+    ...idl.metadata,
+    address: 'A1BvUFMKzoubnHEFhvhJxXyTfEN6r2DqCZxJFF9hfH3x',
+  }
+  const gen = new Solita(idl, { formatCode: true })
+  await gen.renderAndWriteTo(generatedSDKDir)
+  await verifyWithTypescriptCompiler(t, generatedSDKDir)
+  await verifySyntacticCorrectnessForGeneratedDir(t, generatedSDKDir)
+  await verifyTopLevelScriptForGeneratedDir(t, generatedSDKDir)
+})

--- a/test/integration/fixtures/feat-fix-anchor-maps.json
+++ b/test/integration/fixtures/feat-fix-anchor-maps.json
@@ -1,0 +1,49 @@
+{
+  "version": "0.1.0",
+  "name": "feat_fix_anchor_maps",
+  "instructions": [],
+  "types": [
+    {
+      "name": "MapsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "hashMapStringU64",
+            "type": {
+              "defined": "HashMap<String,u64>"
+            }
+          },
+          {
+            "name": "hashMapCustomType",
+            "type": {
+              "defined": "HashMap<String,DataItem>"
+            }
+          },
+          {
+            "name": "bTreeMapU8I128",
+            "type": {
+              "defined": "BTreeMap<u8,i128>"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DataItem",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "uuid",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank",
+    "address": "packFeFNZzMfD9aVWL7QbGz1WcU7R9zpf6pvNsw2BLu"
+  }
+}


### PR DESCRIPTION
Anchor does not support map types like `HashMap` and thus treats them as user defined types
basically just copy/pasting the type from the Rust code, i.e. `HashMap<String,DataItem>`.

This PR adds a transformer function that runs _before_ types are processed. This transformer
tries to detect these cases and converts them to proper _map_ type definitions.
This won't work for 100% of the cases and thus is a stop gap for the cases we encounter for our
anchor programs.
Additionaly at this point it only transforms _fields_ for structs, i.e. if such an invalid map
definition is nested somehow, it will go undetected.
These limitations can be improved on with each new case we need to handle.

FIXES: #75
