### PR TITLE
feat: anchor remaining accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Run it each time you make a change to your program to generate the TypeScript SD
 Since we're writing the _anchor_ binary to `.crates/` you should add that folder to your
 `.gitignore`.
 
+
+**NOTE**: that for _anchor_ generated IDL an optional `anchorRemainingAccounts` property is
+added to each set of instruction accounts. If your programs are not using those you can
+specifically turn that off by setting `anchorRemainingAccounts: false`.
+
 ### Full Example: MPL Candy Machine Solita + Anchor Setup
   
 - [annotated anchor program](https://github.com/metaplex-foundation/metaplex-program-library/blob/5f0c0656ff250f7a70643c06306962186f37ef5d/candy-machine/program/src/lib.rs) 

--- a/src/cli/gen-typescript.ts
+++ b/src/cli/gen-typescript.ts
@@ -8,7 +8,8 @@ export function generateTypeScriptSDK(
   sdkDir: string,
   prettierConfig?: PrettierOptions,
   typeAliases?: TypeAliases,
-  serializers?: Serializers
+  serializers?: Serializers,
+  anchorRemainingAccounts?: boolean
 ) {
   logInfo('Generating TypeScript SDK to %s', sdkDir)
   const gen = new Solita(idl, {
@@ -16,6 +17,7 @@ export function generateTypeScriptSDK(
     formatOpts: prettierConfig,
     typeAliases,
     serializers,
+    anchorRemainingAccounts,
   })
   return gen.renderAndWriteTo(sdkDir)
 }

--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -31,7 +31,14 @@ export function handleAnchor(
     ...config.rustbin,
   }
 
-  return handle(config, rustbinConfig, spawnArgs, spawnOpts, prettierConfig)
+  return handle(
+    config,
+    rustbinConfig,
+    spawnArgs,
+    spawnOpts,
+    prettierConfig,
+    config.anchorRemainingAccounts
+  )
 }
 
 export function handleShank(
@@ -52,7 +59,14 @@ export function handleShank(
     dryRun: false,
   }
 
-  return handle(config, rustbinConfig, spawnArgs, spawnOpts, prettierConfig)
+  return handle(
+    config,
+    rustbinConfig,
+    spawnArgs,
+    spawnOpts,
+    prettierConfig,
+    false
+  )
 }
 
 async function handle(
@@ -60,7 +74,8 @@ async function handle(
   rustbinConfig: RustbinConfig,
   spawnArgs: string[],
   spawnOpts: SpawnOptionsWithoutStdio,
-  prettierConfig?: PrettierOptions
+  prettierConfig?: PrettierOptions,
+  anchorRemainingAccounts?: boolean
 ) {
   const { programName, idlDir, sdkDir } = config
 
@@ -88,7 +103,8 @@ async function handle(
           sdkDir,
           prettierConfig,
           config.typeAliases,
-          config.serializers
+          config.serializers,
+          anchorRemainingAccounts
         )
         resolve()
       })

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -17,6 +17,7 @@ export type SolitaConfigBase = {
 export type SolitaConfigAnchor = SolitaConfigBase & {
   idlGenerator: 'anchor'
   programId: string
+  anchorRemainingAccounts?: boolean
 }
 
 export type SolitaConfigShank = SolitaConfigBase & {

--- a/src/solita.ts
+++ b/src/solita.ts
@@ -19,6 +19,7 @@ import {
   IdlTypeDataEnum,
   IdlTypeEnum,
   IdlFieldsType,
+  isAnchorIdl,
 } from './types'
 import {
   logDebug,
@@ -54,6 +55,7 @@ export type SolitaOpts = {
   typeAliases?: TypeAliases
   serializers?: Serializers
   projectRoot?: string
+  anchorRemainingAccounts?: boolean
 }
 
 export class Solita {
@@ -65,6 +67,7 @@ export class Solita {
   private readonly serializers: CustomSerializers
   private readonly projectRoot: string
   private readonly hasInstructions: boolean
+  private readonly anchorRemainingAccounts: boolean
   private paths: Paths | undefined
   constructor(
     private readonly idl: Idl,
@@ -75,6 +78,7 @@ export class Solita {
       typeAliases = {},
       serializers = {},
       projectRoot = process.cwd(),
+      anchorRemainingAccounts,
     }: SolitaOpts = {}
   ) {
     this.projectRoot = projectRoot
@@ -88,6 +92,10 @@ export class Solita {
       new Map(Object.entries(serializers))
     )
     this.hasInstructions = idl.instructions.length > 0
+
+    // Unless remaining accounts are specifically turned off, we support them
+    // for anchor programs
+    this.anchorRemainingAccounts = anchorRemainingAccounts ?? isAnchorIdl(idl)
   }
 
   // -----------------
@@ -220,7 +228,8 @@ export class Solita {
         accountFiles,
         customFiles,
         this.typeAliases,
-        forceFixable
+        forceFixable,
+        this.anchorRemainingAccounts
       )
       if (this.prependGeneratedWarning) {
         code = prependGeneratedWarning(code)

--- a/src/types.ts
+++ b/src/types.ts
@@ -368,6 +368,11 @@ export function isShankIdl(ty: Idl): ty is ShankIdl {
   return (ty as ShankIdl).metadata?.origin === 'shank'
 }
 
+export function isAnchorIdl(ty: Idl): ty is ShankIdl {
+  // This needs to change once we support more than two IDL generators
+  return !isShankIdl(ty)
+}
+
 export function isShankIdlInstruction(
   ty: IdlInstruction
 ): ty is ShankIdlInstruction {

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -29,6 +29,7 @@ async function checkRenderedIx(
     lineNumbers?: boolean
     rxs?: RegExp[]
     nonrxs?: RegExp[]
+    anchorRemainingAccounts?: boolean
   } = {}
 ) {
   const {
@@ -45,7 +46,8 @@ async function checkRenderedIx(
     new Map(),
     new Map(),
     new Map(),
-    FORCE_FIXABLE_NEVER
+    FORCE_FIXABLE_NEVER,
+    opts.anchorRemainingAccounts ?? false
   )
   if (logCode) {
     const renderTs = lineNumbers
@@ -123,7 +125,9 @@ test('ix: one arg', async (t) => {
       },
     ],
   }
-  await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE])
+  await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
+    nonrxs: [/anchorRemainingAccounts\?\: web3\.AccountMeta\[\]/],
+  })
 })
 
 test('ix: two args', async (t) => {
@@ -348,5 +352,31 @@ test('ix: empty args one system program account + one optional rent account', as
       /pubkey\: accounts.rent,/,
     ],
     nonrxs: [/pubkey\: accounts\.programId/],
+  })
+})
+
+// -----------------
+// Anchor Remaining Accounts
+// -----------------
+test('ix: one arg rendering remaining accounts', async (t) => {
+  const ix = <IdlInstruction>{
+    name: 'oneArg',
+    accounts: [
+      {
+        name: 'authority',
+        isMut: false,
+        isSigner: true,
+      },
+    ],
+    args: [
+      {
+        name: 'amount',
+        type: 'u64',
+      },
+    ],
+  }
+  await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
+    rxs: [/anchorRemainingAccounts\?\: web3\.AccountMeta\[\]/],
+    anchorRemainingAccounts: true,
   })
 })


### PR DESCRIPTION
## Summary

For anchor programs solita now renders an optional `anchorRemainingAccounts` property for the instruction
accounts, allowing users to specify them.

This can be turned off by setting `anchorRemainingAccounts = false` in the solita config.

Renders code outlined in [this
issue](https://github.com/metaplex-foundation/metaplex-program-library/issues/678) and thus fixes it.

## Sample Code Rendered

```ts
export type ExecuteSaleInstructionAccounts = {
  buyer: web3.PublicKey
  seller: web3.PublicKey
  tokenAccount: web3.PublicKey
  tokenMint: web3.PublicKey
  [ .. many more .. ]
  programAsSigner: web3.PublicKey
  rent?: web3.PublicKey
  anchorRemainingAccounts?: web3.AccountMeta[]
}

[ .. ]

export function createExecuteSaleInstruction(
  accounts: ExecuteSaleInstructionAccounts,
  args: ExecuteSaleInstructionArgs,
  programId = new web3.PublicKey('hausS13jsjafwWwGqZTUQRmWyvyxn9EQpqMwV1PBBmk')
) {
  const [data] = executeSaleStruct.serialize({
    instructionDiscriminator: executeSaleInstructionDiscriminator,
    ...args,
  })
  const keys: web3.AccountMeta[] = [
    {
      pubkey: accounts.buyer,
      isWritable: true,
      isSigner: false,
    },
    {
      pubkey: accounts.seller,
      isWritable: true,
      isSigner: false,
    },
   [ .. many more .. ]
  }

  if (accounts.anchorRemainingAccounts != null) {
    for (const acc of accounts.anchorRemainingAccounts) {
      keys.push(acc)
    }
  }

  const ix = new web3.TransactionInstruction({
    programId,
    keys,
    data,
  })
  return ix
```
