### PR TITLE
fix: handling empty accounts for anchor remaining accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@metaplex-foundation/beet": "^0.6.0",
     "@metaplex-foundation/beet-solana": "^0.3.0",
     "@metaplex-foundation/rustbin": "^0.3.0",
-    "@solana/web3.js": "^1.36.0",
+    "@solana/web3.js": "^1.56.2",
     "camelcase": "^6.2.1",
     "debug": "^4.3.3",
     "js-sha256": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.6.0",
-    "@metaplex-foundation/beet-solana": "^0.3.0",
+    "@metaplex-foundation/beet": "^0.6.1",
+    "@metaplex-foundation/beet-solana": "^0.3.1",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.56.2",
     "camelcase": "^6.2.1",

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -136,15 +136,16 @@ ${typeMapperImports.join('\n')}`.trim()
       return true
     })
 
-    const anchorRemainingAccounts = this.renderAnchorRemainingAccounts
-      ? `
+    const anchorRemainingAccounts =
+      this.renderAnchorRemainingAccounts && processedKeys.length > 0
+        ? `
   if (accounts.anchorRemainingAccounts != null) {
     for (const acc of accounts.anchorRemainingAccounts) {
       keys.push(acc)
     }
   }
 `
-      : ''
+        : ''
 
     const requiredKeys = requireds
       .map(({ name, isMut, isSigner, knownPubkey }) => {

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -380,3 +380,40 @@ test('ix: one arg rendering remaining accounts', async (t) => {
     anchorRemainingAccounts: true,
   })
 })
+
+test('ix: empty args rendering remaining accounts', async (t) => {
+  const ix = {
+    name: 'empyArgs',
+    accounts: [
+      {
+        name: 'authority',
+        isMut: false,
+        isSigner: true,
+      },
+    ],
+    args: [],
+  }
+  await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
+    logCode: false,
+    rxs: [
+      /programId = new web3\.PublicKey/,
+      /anchorRemainingAccounts\?\: web3\.AccountMeta\[\]/,
+    ],
+    anchorRemainingAccounts: true,
+  })
+})
+
+test('ix: empty args and empty accounts', async (t) => {
+  const ix = {
+    name: 'empyArgs',
+    accounts: [],
+    args: [],
+  }
+  await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
+    logCode: false,
+    rxs: [/programId = new web3\.PublicKey/],
+    nonrxs: [/anchorRemainingAccounts\?\: web3\.AccountMeta\[\]/],
+    anchorRemainingAccounts: true,
+  })
+  t.end()
+})


### PR DESCRIPTION
# Summary

The intent of this PR was to just handle the case of empty accounts when we try to add
`anchorRemainingAccounts`. In this case we just assume that there are none and thus don't
render any of the code allowing users to add them.

If this assumption was wrong we need to iterate on this solution.

As a side effect I ran into issues with web3.js (missing cross-fetch) which originated from it
being a dep of beet-solita.
Thus after [upgrading numerous deps in the beet
repo](https://github.com/metaplex-foundation/beet/pull/42) we updated the beet deps here to
pull in those patches.
