### PR TITLE
feat: support account collections for instructions

### DIFF
--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -118,36 +118,35 @@ ${typeMapperImports.join('\n')}`.trim()
   // -----------------
   private processIxAccounts(): ProcessedAccountKey[] {
     let processedAccountsKey: ProcessedAccountKey[] = []
-    this.ix.accounts.map((acc: IdlInstructionAccount | IdlAccountsCollection) => {
-      if(this.isAccountsCollection(acc)){
-        acc.accounts.map((ac) => {
+    for (const acc of this.ix.accounts) {
+      if (this.isAccountsCollection(acc)) {
+        for (const ac of acc.accounts) {
           // as there are cases where the collection of the accounts is reused on the same ix, is needed to change the name of the account
           ac.name += acc.name.charAt(0).toUpperCase().concat(acc.name.slice(1))
           const knownPubkey = resolveKnownPubkey(ac.name)
           const optional = ac.optional ?? false
           if (knownPubkey == null) {
             processedAccountsKey.push({ ...ac, optional })
-          }
-          else{
+          } else {
             processedAccountsKey.push({ ...ac, knownPubkey, optional })
           }
-        })
-      }
-      else {
+        }
+      } else {
         const knownPubkey = resolveKnownPubkey(acc.name)
         const optional = acc.optional ?? false
         if (knownPubkey == null) {
           processedAccountsKey.push({ ...acc, optional })
-        }
-        else{
+        } else {
           processedAccountsKey.push({ ...acc, knownPubkey, optional })
         }
       }
-    })
+    }
     return processedAccountsKey
   }
 
-  protected isAccountsCollection(account: IdlInstructionAccount | IdlAccountsCollection): account is IdlAccountsCollection {
+  private isAccountsCollection(
+    account: IdlInstructionAccount | IdlAccountsCollection
+  ): account is IdlAccountsCollection {
     return (account as IdlAccountsCollection).accounts !== undefined
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,7 +148,7 @@ export type IdlInstructionArg = {
 
 export type IdlInstruction = {
   name: string
-  accounts: IdlInstructionAccount[]
+  accounts: IdlInstructionAccount[] | IdlAccountsCollection[]
   args: IdlInstructionArg[]
 }
 
@@ -163,6 +163,11 @@ export type IdlAccountType = {
 export type IdlAccount = {
   name: string
   type: IdlAccountType
+}
+
+export type IdlAccountsCollection = {
+  name: string
+  accounts: IdlInstructionAccount[]
 }
 
 export type IdlError = {

--- a/test/integration/features.ts
+++ b/test/integration/features.ts
@@ -117,7 +117,7 @@ import collectionAccountsJson from './fixtures/collection-accounts.json'
   })
 }
 // -----------------
-// feat-tuples
+// feat-collections-accounts
 // -----------------
 {
   const label = 'feat-collections-accounts'

--- a/test/integration/features.ts
+++ b/test/integration/features.ts
@@ -9,6 +9,7 @@ import fixAnchorMapsJson from './fixtures/feat-fix-anchor-maps.json'
 import mixedEnumsWithCustomTypesJson from './fixtures/feat-mixed-enums+custom-types.json'
 import mixedEnumsJson from './fixtures/feat-mixed-enums.json'
 import tuplesJson from './fixtures/feat-tuples.json'
+import collectionAccountsJson from './fixtures/collection-accounts.json'
 
 // -----------------
 // feat-account-padding
@@ -108,6 +109,21 @@ import tuplesJson from './fixtures/feat-tuples.json'
 
   test('renders type correct SDK for ' + label, async (t) => {
     const idl = tuplesJson as Idl
+    idl.metadata = {
+      ...idl.metadata,
+      address: 'A1BvUFMKzoubnHEFhvhJxXyTfEN6r2DqCZxJFF9hfH3x',
+    }
+    await checkIdl(t, idl, label)
+  })
+}
+// -----------------
+// feat-tuples
+// -----------------
+{
+  const label = 'feat-collections-accounts'
+
+  test('renders type correct SDK for ' + label, async (t) => {
+    const idl = collectionAccountsJson as Idl
     idl.metadata = {
       ...idl.metadata,
       address: 'A1BvUFMKzoubnHEFhvhJxXyTfEN6r2DqCZxJFF9hfH3x',

--- a/test/integration/fixtures/collection-accounts.json
+++ b/test/integration/fixtures/collection-accounts.json
@@ -1,0 +1,195 @@
+{
+  "version": "0.2.0",
+  "name": "jet",
+  "instructions": [
+    {
+      "name": "mockLiquidateDex",
+      "accounts": [
+        {
+          "name": "sourceMarket",
+          "accounts": [
+            {
+              "name": "market",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "requestQueue",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "eventQueue",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "bids",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "asks",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "coinVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "pcVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "vaultSigner",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "targetMarket",
+          "accounts": [
+            {
+              "name": "market",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "requestQueue",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "eventQueue",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "bids",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "asks",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "coinVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "pcVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "vaultSigner",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "toLiquidate",
+          "accounts": [
+            {
+              "name": "market",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "obligation",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "loanReserve",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "loanReserveVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "loanNoteMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "loanAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "collateralReserve",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "collateralReserveVault",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "depositNoteMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "collateralAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexSwapTokens",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "rent",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": []
+    }
+  ],
+  "metadata": {
+    "address": "test"
+  }
+}


### PR DESCRIPTION
Now this case of IDL is taken into account.
FIXES: #78

The problem you said in the issue is solved (A instruction should just have a list of accounts, each of type AccountMetadata (not arrays or anything else), but not 100% sure if it is the best way, as I included in the code as a commentary:

as there are cases where the collection of the accounts is reused on the same ix, is needed to change the name of the account (because in that case would be accounts in the same instruction with the same name)

To solve that, I have included on the accounts the name of the list of the accounts.

This case appears on the IDL of Marinade Finance, Jet Protocol and Jupiter, so would be great to fix.