### PR TITLE
feat: support sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
-    "@metaplex-foundation/beet": "^0.6.1",
+    "@metaplex-foundation/beet": "^0.7.1",
     "@metaplex-foundation/beet-solana": "^0.3.1",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.56.2",

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type IdlType =
   | IdlTypeDataEnum
   | IdlTypeTuple
   | IdlTypeMap
+  | IdlTypeSet
 
 // User defined type.
 export type IdlTypeDefined = {
@@ -123,6 +124,17 @@ export type IdlTypeHashMap = {
 }
 export type IdlTypeBTreeMap = {
   bTreeMap: [IdlType, IdlType]
+}
+
+// -----------------
+// Sets
+// -----------------
+export type IdlTypeSet = IdlTypeHashSet | IdlTypeBTreeSet
+export type IdlTypeHashSet = {
+  hashSet: IdlType
+}
+export type IdlTypeBTreeSet = {
+  bTreeSet: IdlType
 }
 
 // -----------------
@@ -331,6 +343,21 @@ export function isIdlTypeBTreeMap(ty: IdlType): ty is IdlTypeBTreeMap {
 
 export function isIdlTypeMap(ty: IdlType): ty is IdlTypeMap {
   return isIdlTypeHashMap(ty) || isIdlTypeBTreeMap(ty)
+}
+
+// -----------------
+// Sets
+// -----------------
+export function isIdlTypeHashSet(ty: IdlType): ty is IdlTypeHashSet {
+  return (ty as IdlTypeHashSet).hashSet != null
+}
+
+export function isIdlTypeBTreeSet(ty: IdlType): ty is IdlTypeBTreeSet {
+  return (ty as IdlTypeBTreeSet).bTreeSet != null
+}
+
+export function isIdlTypeSet(ty: IdlType): ty is IdlTypeSet {
+  return isIdlTypeHashSet(ty) || isIdlTypeBTreeSet(ty)
 }
 
 // -----------------

--- a/test/integration/features.ts
+++ b/test/integration/features.ts
@@ -122,7 +122,7 @@ import setsJson from './fixtures/feat-sets.json'
 {
   const label = 'feat-sets'
 
-  test.only('renders type correct SDK for ' + label, async (t) => {
+  test('renders type correct SDK for ' + label, async (t) => {
     const idl = setsJson as Idl
     idl.metadata = {
       ...idl.metadata,

--- a/test/integration/features.ts
+++ b/test/integration/features.ts
@@ -9,6 +9,7 @@ import fixAnchorMapsJson from './fixtures/feat-fix-anchor-maps.json'
 import mixedEnumsWithCustomTypesJson from './fixtures/feat-mixed-enums+custom-types.json'
 import mixedEnumsJson from './fixtures/feat-mixed-enums.json'
 import tuplesJson from './fixtures/feat-tuples.json'
+import setsJson from './fixtures/feat-sets.json'
 
 // -----------------
 // feat-account-padding
@@ -108,6 +109,21 @@ import tuplesJson from './fixtures/feat-tuples.json'
 
   test('renders type correct SDK for ' + label, async (t) => {
     const idl = tuplesJson as Idl
+    idl.metadata = {
+      ...idl.metadata,
+      address: 'A1BvUFMKzoubnHEFhvhJxXyTfEN6r2DqCZxJFF9hfH3x',
+    }
+    await checkIdl(t, idl, label)
+  })
+}
+// -----------------
+// feat-sets
+// -----------------
+{
+  const label = 'feat-sets'
+
+  test.only('renders type correct SDK for ' + label, async (t) => {
+    const idl = setsJson as Idl
     idl.metadata = {
       ...idl.metadata,
       address: 'A1BvUFMKzoubnHEFhvhJxXyTfEN6r2DqCZxJFF9hfH3x',

--- a/test/integration/fixtures/feat-sets.json
+++ b/test/integration/fixtures/feat-sets.json
@@ -1,0 +1,119 @@
+{
+  "version": "0.1.0",
+  "name": "feat_sets",
+  "instructions": [],
+  "types": [
+    {
+      "name": "OneHashSetStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8Set",
+            "type": {
+              "hashSet": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultipleHashSetsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8Set",
+            "type": {
+              "hashSet": "u8"
+            }
+          },
+          {
+            "name": "stringSet",
+            "type": {
+              "hashSet": "string"
+            }
+          },
+          {
+            "name": "optionI128Set",
+            "type": {
+              "hashSet": {
+                "option": "i128"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OneBTreeSetStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8Set",
+            "type": {
+              "bTreeSet": "u8"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultipleBTreeSetsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "u8Set",
+            "type": {
+              "bTreeSet": "u8"
+            }
+          },
+          {
+            "name": "stringSet",
+            "type": {
+              "bTreeSet": "string"
+            }
+          },
+          {
+            "name": "optionI128Set",
+            "type": {
+              "bTreeSet": {
+                "option": "i128"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "NestedSetsStruct",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vecHashSet",
+            "type": {
+              "vec": {
+                "hashSet": "u8"
+              }
+            }
+          },
+          {
+            "name": "optionBtreeSetU8",
+            "type": {
+              "option": {
+                "bTreeSet": "u8"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank",
+    "address": "packFeFNZzMfD9aVWL7QbGz1WcU7R9zpf6pvNsw2BLu"
+  }
+}


### PR DESCRIPTION
# Summary

Solita now renders code for `hashSet` and `bTreeSet` similarly to how was done for maps
https://github.com/metaplex-foundation/solita/pull/73.

An integration test with set samples was included.


Related shank PR: https://github.com/metaplex-foundation/shank/pull/38
