### PR TITLE
feat: accounts api fromAccounts improvement

### DIFF
--- a/src/render-account.ts
+++ b/src/render-account.ts
@@ -359,8 +359,9 @@ export class ${this.accountDataClassName} implements ${this.accountDataArgsTypeN
   static async fromAccountAddress(
     connection: web3.Connection,
     address: web3.PublicKey,
+    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig,
   ): Promise<${this.accountDataClassName}> {
-    const accountInfo = await connection.getAccountInfo(address);
+    const accountInfo = await connection.getAccountInfo(address, commitmentOrConfig);
     if (accountInfo == null) {
       throw new Error(\`Unable to find ${this.accountDataClassName} account at \${address}\`);
     }


### PR DESCRIPTION
# Summary

The accounts method `fromAccountAddress` now supports a `commitment` parameter to be specified.

Fixes: #84


## Sample Code

```ts
  static async fromAccountAddress(
    connection: web3.Connection,
    address: web3.PublicKey,
    commitmentOrConfig?: web3.Commitment | web3.GetAccountInfoConfig
  ): Promise<MasterEditionV1> {
    const accountInfo = await connection.getAccountInfo(
      address,
      commitmentOrConfig
    )
    if (accountInfo == null) {
      throw new Error(`Unable to find MasterEditionV1 account at ${address}`)
    }
    return MasterEditionV1.fromAccountInfo(accountInfo, 0)[0]
  }
```