### PR TITLE
feat: better errors when IDL handler fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@metaplex-foundation/beet-solana": "^0.3.1",
     "@metaplex-foundation/rustbin": "^0.3.0",
     "@solana/web3.js": "^1.56.2",
+    "ansi-colors": "^4.1.3",
     "camelcase": "^6.2.1",
     "debug": "^4.3.3",
     "js-sha256": "^0.9.0",

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -26,6 +26,8 @@ export type SolitaConfigShank = SolitaConfigBase & {
 
 export type SolitaConfig = SolitaConfigAnchor | SolitaConfigShank
 
+export type SolitaHandlerResult = { exitCode: number; errorMsg?: string }
+
 // -----------------
 // Guards
 // -----------------
@@ -39,4 +41,10 @@ export function isSolitaConfigShank(
   config: SolitaConfig
 ): config is SolitaConfigShank {
   return config.idlGenerator === 'shank'
+}
+
+export function isErrorResult(
+  result: SolitaHandlerResult
+): result is SolitaHandlerResult & { errorMsg: string } {
+  return result.errorMsg != null
 }


### PR DESCRIPTION
# Summary

Previously solita failed to properly propagate exit codes of the tool generating the IDL. This
led to developers not being aware of the issue as well as the CI checking for IDL changes not
alerting either since in those cases solita just kept the old IDL and generated code from it.

This has been fixed as follows:

- non-zero exit codes of the handler tool, i.e. anchor are now propagated and solita will exit
  with it to also return a non-zero exit code
- if an `Error:` is encountered in the `stderr` output of the handler tool then solita will
  color it red to draw attention.
- the message alerting the user that something went wrong is also colored red

## Sample Screenshot

<img width="1047" alt="Screen Shot 2022-09-23 at 10 31 58 AM" src="https://user-images.githubusercontent.com/192891/192009787-7e61cb7d-eee5-48ee-affc-5bb47721d80b.png">

## Remaining Work

To further eliminate the possibility of the IDL generation failing without solita noticing I
will add an option to delete the existing IDL before solita runs. This option will be set to
`true` by default.
