### PR TITLE
feat: optionally removing existing IDL file before running

### DIFF
--- a/src/cli/solita.ts
+++ b/src/cli/solita.ts
@@ -2,7 +2,13 @@
 
 import path from 'path'
 import fs from 'fs'
-import { canAccess, logDebug, logError, logInfo } from '../utils'
+import {
+  canAccess,
+  logDebug,
+  logError,
+  logInfo,
+  removeFileIfExists,
+} from '../utils'
 import {
   isErrorResult,
   isSolitaConfigAnchor,
@@ -42,6 +48,19 @@ async function main() {
       `Unable to find solita config '.solitarc.js' in the current directory (${process.cwd()} `
     )
   }
+
+  const removeIdl = solitaConfig.removeExistingIdl ?? true
+  if (removeIdl) {
+    const { idlDir, programName } = solitaConfig
+    const idlFile = path.join(idlDir, `${programName}.json`)
+    const removed = await removeFileIfExists(idlFile)
+    if (removed) {
+      logInfo(
+        `Removed existing IDL at ${idlFile}.\nDisable this by setting 'removeExistingIdl: false' inside the '.solitarc.js' config.`
+      )
+    }
+  }
+
   const prettierRes = await tryLoadLocalConfigRc(PRETTIER_CONFIG_RCS)
   const prettierConfig = prettierRes?.config
   if (prettierConfig != null) {

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -12,6 +12,7 @@ export type SolitaConfigBase = {
   rustbin?: RustbinConfig
   typeAliases?: TypeAliases
   serializers?: Serializers
+  removeExistingIdl?: boolean
 }
 
 export type SolitaConfigAnchor = SolitaConfigBase & {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -72,6 +72,16 @@ export function withoutTsExtension(p: string) {
   return p.replace(/\.ts$/, '')
 }
 
+export async function removeFileIfExists(file: string) {
+  try {
+    await fs.access(file)
+  } catch (_) {
+    return false
+  }
+  await fs.rm(file)
+  return true
+}
+
 export function prependGeneratedWarning(code: string) {
   return `
 /**


### PR DESCRIPTION
# Summary

Adds onto #90 to make it less likely that a failure to generate the IDL file goes unnoticed.

FIXES: #89
