### PR TITLE
Feat: programId replacement style optional accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:anchor:basic3": "cd ./test/anchor-examples/basic-3 && yarn test",
     "test:anchor:basic4": "cd ./test/anchor-examples/basic-4 && yarn test",
     "lint": "prettier -c ./src/",
-    "lint:fix": "prettier --format ./src",
+    "lint:fix": "prettier --write ./src",
     "doc": "rimraf ./docs && typedoc",
     "doc:update": "./sh/update-docs",
     "doctoc": "doctoc README.md"

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -385,7 +385,6 @@ ${accountsType}
     ${accountsParamDoc}${createInstructionArgsComment}
      * @category Instructions
      * @category ${this.upperCamelIxName}
-     * @category ${this.upperCamelIxName}
      * @category generated
      */
     export function create${this.upperCamelIxName}Instruction(

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -66,7 +66,7 @@ class InstructionRenderer {
       typeMapper
     )
     this.programIdPubkey = `new ${SOLANA_WEB3_EXPORT_NAME}.PublicKey('${this.programId}')`
-    this.defaultOptionalAccounts = !!ix.defaultOptionalsToProgramId
+    this.defaultOptionalAccounts = ix.defaultOptionalAccounts ?? false
   }
 
   // -----------------
@@ -189,8 +189,8 @@ ${typeMapperImports.join('\n')}`.trim()
         let pubkey, mut, signer
         if (optional) {
           pubkey = `accounts.${name} ?? programId`
-          mut = isMut ? `accounts.${name} ?? false` : 'false'
-          signer = isSigner ? `accounts.${name} ?? false` : 'false'
+          mut = isMut ? `accounts.${name} != null` : 'false'
+          signer = isSigner ? `accounts.${name} != null` : 'false'
         } else {
           pubkey =
             knownPubkey == null

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -192,12 +192,17 @@ ${typeMapperImports.join('\n')}`.trim()
     return this.renderAccountMeta(pubkey, mut, signer)
   }
 
-  private renderAccountMetaArray(processedKeys: ProcessedAccountKey[]) {
+  private renderAccountMetaArray(
+    processedKeys: ProcessedAccountKey[],
+    inLineOptionalStrategy?: (key: ProcessedAccountKey) => string
+  ) {
     const metaElements = processedKeys
       .map((processedKey) => {
-        return processedKey.optional
-          ? this.renderDefaultOptionalAccountMeta(processedKey)
-          : this.renderRequiredAccountMeta(processedKey)
+        if (processedKey.optional && inLineOptionalStrategy) {
+          return inLineOptionalStrategy(processedKey)
+        } else {
+          return this.renderRequiredAccountMeta(processedKey)
+        }
       })
       .join(',\n    ')
     return `[\n    ${metaElements}\n  ]`
@@ -253,7 +258,10 @@ ${typeMapperImports.join('\n')}`.trim()
 
   private renderIxAccountKeys(processedKeys: ProcessedAccountKey[]) {
     const fixedAccountKeys = this.defaultOptionalAccounts
-      ? this.renderAccountMetaArray(processedKeys)
+      ? this.renderAccountMetaArray(
+          processedKeys,
+          this.renderDefaultOptionalAccountMeta.bind(this)
+        )
       : this.renderOptionalAtEndAccountMetas(processedKeys)
 
     const anchorRemainingAccounts =

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -189,8 +189,8 @@ ${typeMapperImports.join('\n')}`.trim()
         let pubkey, mut, signer
         if (optional) {
           pubkey = `accounts.${name} ?? programId`
-          mut = isMut ? `!!accounts.${name}` : 'false'
-          signer = isSigner ? `!!accounts.${name}` : 'false'
+          mut = isMut ? `accounts.${name} ?? false` : 'false'
+          signer = isSigner ? `accounts.${name} ?? false` : 'false'
         } else {
           pubkey =
             knownPubkey == null

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -192,17 +192,12 @@ ${typeMapperImports.join('\n')}`.trim()
     return this.renderAccountMeta(pubkey, mut, signer)
   }
 
-  private renderAccountMetaArray(
-    processedKeys: ProcessedAccountKey[],
-    inLineOptionalStrategy?: (key: ProcessedAccountKey) => string
-  ) {
+  private renderAccountMetaArray(processedKeys: ProcessedAccountKey[]) {
     const metaElements = processedKeys
       .map((processedKey) => {
-        if (processedKey.optional && inLineOptionalStrategy) {
-          return inLineOptionalStrategy(processedKey)
-        } else {
-          return this.renderRequiredAccountMeta(processedKey)
-        }
+        return processedKey.optional
+          ? this.renderDefaultOptionalAccountMeta(processedKey)
+          : this.renderRequiredAccountMeta(processedKey)
       })
       .join(',\n    ')
     return `[\n    ${metaElements}\n  ]`
@@ -258,10 +253,7 @@ ${typeMapperImports.join('\n')}`.trim()
 
   private renderIxAccountKeys(processedKeys: ProcessedAccountKey[]) {
     const fixedAccountKeys = this.defaultOptionalAccounts
-      ? this.renderAccountMetaArray(
-          processedKeys,
-          this.renderDefaultOptionalAccountMeta.bind(this)
-        )
+      ? this.renderAccountMetaArray(processedKeys)
       : this.renderOptionalAtEndAccountMetas(processedKeys)
 
     const anchorRemainingAccounts =

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -37,7 +37,7 @@ class InstructionRenderer {
   readonly accountsTypename: string
   readonly instructionDiscriminatorName: string
   readonly structArgName: string
-  private readonly defaultOptionalsToProgramId: boolean
+  private readonly defaultOptionalAccounts: boolean
   private readonly instructionDiscriminator: InstructionDiscriminator
   private readonly programIdPubkey: string
 
@@ -66,7 +66,7 @@ class InstructionRenderer {
       typeMapper
     )
     this.programIdPubkey = `new ${SOLANA_WEB3_EXPORT_NAME}.PublicKey('${this.programId}')`
-    this.defaultOptionalsToProgramId = !!ix.defaultOptionalsToProgramId
+    this.defaultOptionalAccounts = !!ix.defaultOptionalsToProgramId
   }
 
   // -----------------
@@ -159,10 +159,10 @@ ${typeMapperImports.join('\n')}`.trim()
   }
 
   private renderIxAccountKeys(processedKeys: ProcessedAccountKey[]) {
-    const requireds = this.defaultOptionalsToProgramId
+    const requireds = this.defaultOptionalAccounts
       ? processedKeys
       : processedKeys.filter((x) => !x.optional)
-    const optionals = this.defaultOptionalsToProgramId
+    const optionals = this.defaultOptionalAccounts
       ? []
       : processedKeys.filter((x, idx) => {
           if (!x.optional) return false

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -401,6 +401,10 @@ ${struct} `.trim()
           ]
     const programIdArg = `${comma}programId = ${this.programIdPubkey}`
 
+    const optionalAccountsComment = optionalAccountsStrategyDocComment(
+      this.defaultOptionalAccounts,
+      processedKeys.some((x) => x.optional)
+    )
     return `${imports}
 
 ${enums}
@@ -411,7 +415,7 @@ ${accountsType}
 
     /**
      * Creates a _${this.upperCamelIxName}_ instruction.
-    ${accountsParamDoc}${createInstructionArgsComment}
+    ${optionalAccountsComment}${accountsParamDoc}${createInstructionArgsComment}
      * @category Instructions
      * @category ${this.upperCamelIxName}
      * @category generated
@@ -512,4 +516,24 @@ function renderRequiredAccountMeta(
           programIdPubkey
         )}`
   return renderAccountMeta(pubkey, isMut.toString(), isSigner.toString())
+}
+
+function optionalAccountsStrategyDocComment(
+  defaultOptionalAccounts: boolean,
+  someAccountIsOptional: boolean
+) {
+  if (!someAccountIsOptional) return ''
+
+  if (defaultOptionalAccounts) {
+    return ` * 
+ * Optional accounts that are not provided default to the program ID since 
+ * this was indicated in the IDL from which this instruction was generated.
+`
+  }
+  return ` * 
+ * Optional accounts that are not provided will be omitted from the accounts
+ * array passed with the instruction.
+ * An optional account that is set cannot follow an optional account that is unset.
+ * Otherwise an Error is raised.
+`
 }

--- a/src/transform-type.ts
+++ b/src/transform-type.ts
@@ -41,6 +41,9 @@ export function adaptIdl(idl: Idl) {
   }
 }
 
+// -----------------
+// Types
+// -----------------
 function transformDefinition(def: IdlDefinedTypeDefinition) {
   const ty = def.type
   if (isFieldsType(ty)) {
@@ -97,3 +100,7 @@ function transformFields(ty: IdlFieldsType) {
   }
   return ty
 }
+
+// -----------------
+// Instruction
+// -----------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ export type IdlInstructionArg = {
 
 export type IdlInstruction = {
   name: string
-  defaultOptionalsToProgramId?: boolean
+  defaultOptionalAccounts?: boolean
   accounts: IdlInstructionAccount[] | IdlAccountsCollection[]
   args: IdlInstructionArg[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,6 +160,7 @@ export type IdlInstructionArg = {
 
 export type IdlInstruction = {
   name: string
+  defaultOptionalsToProgramId?: boolean
   accounts: IdlInstructionAccount[] | IdlAccountsCollection[]
   args: IdlInstructionArg[]
 }

--- a/test/integration/contracts.ts
+++ b/test/integration/contracts.ts
@@ -4,6 +4,7 @@ import { Idl } from '../../src/solita'
 import test from 'tape'
 import { checkIdl } from '../utils/check-idl'
 
+import anchorOptional from './fixtures/anchor-optional.json'
 import auctionHouseAnchor24Json from './fixtures/auction_house-1.1.4-anchor-0.24.2.json'
 import auctionHouseJson from './fixtures/auction_house.json'
 import fanoutJson from './fixtures/fanout.json'
@@ -15,6 +16,21 @@ import shankTicTacToeJson from './fixtures/shank_tictactoe.json'
 import shankTokenMetadataJson from './fixtures/shank_token_metadata.json'
 import shankTokenVaultJson from './fixtures/shank_token_vault.json'
 
+
+// -----------------
+// anchor-optional
+// -----------------
+{
+  const label = 'anchor-optional'
+
+  test('renders type correct SDK for ' + label, async (t) => {
+    const idl = anchorOptional as Idl
+    idl.instructions.map(ix => {
+      ix.defaultOptionalAccounts = true
+    })
+    await checkIdl(t, idl, label)
+  })
+}
 // -----------------
 // ah-1.1.4-anchor-0.24.2
 // -----------------
@@ -138,13 +154,14 @@ import shankTokenVaultJson from './fixtures/shank_token_vault.json'
       const code = await fs.readFile(fullPath, 'utf8')
       t.match(code, rx, `Code inside ${relPath} matches ${rx.toString()}`)
     }
+
     await verifyCodeMatches(
       'types/Data.ts',
-      /FixableBeetArgsStruct<\s*Data\s*>/
+      /FixableBeetArgsStruct<\s*Data\s*>/,
     )
     await verifyCodeMatches(
       'instructions/CreateMetadataAccount.ts',
-      /FixableBeetArgsStruct<\s*CreateMetadataAccountInstructionArgs/
+      /FixableBeetArgsStruct<\s*CreateMetadataAccountInstructionArgs/,
     )
   })
 }

--- a/test/integration/features.ts
+++ b/test/integration/features.ts
@@ -11,6 +11,7 @@ import mixedEnumsJson from './fixtures/feat-mixed-enums.json'
 import tuplesJson from './fixtures/feat-tuples.json'
 import setsJson from './fixtures/feat-sets.json'
 import collectionAccountsJson from './fixtures/feat-collection-accounts.json'
+import optionalAccountsJson from './fixtures/feat-optional-accounts.json'
 
 // -----------------
 // feat-account-padding
@@ -144,6 +145,17 @@ import collectionAccountsJson from './fixtures/feat-collection-accounts.json'
       ...idl.metadata,
       address: 'A1BvUFMKzoubnHEFhvhJxXyTfEN6r2DqCZxJFF9hfH3x',
     }
+    await checkIdl(t, idl, label)
+  })
+}
+// -----------------
+// feat-optional-accounts
+// -----------------
+{
+  const label = 'feat-optional-accounts'
+
+  test('renders type correct SDK for ' + label, async (t) => {
+    const idl = optionalAccountsJson as Idl
     await checkIdl(t, idl, label)
   })
 }

--- a/test/integration/fixtures/anchor-optional.json
+++ b/test/integration/fixtures/anchor-optional.json
@@ -1,0 +1,193 @@
+{
+  "version": "0.1.0",
+  "name": "optional",
+  "instructions": [
+    {
+      "name": "initialize",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "optional": true
+        },
+        {
+          "name": "optionalAccount",
+          "isMut": true,
+          "isSigner": true,
+          "optional": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "optional": true
+        },
+        {
+          "name": "required",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "optionalPda",
+          "isMut": true,
+          "isSigner": false,
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "value",
+          "type": "u64"
+        },
+        {
+          "name": "key",
+          "type": "publicKey"
+        }
+      ]
+    },
+    {
+      "name": "update",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "optional": true
+        },
+        {
+          "name": "optionalPda",
+          "isMut": true,
+          "isSigner": false,
+          "optional": true
+        },
+        {
+          "name": "optionalAccount",
+          "isMut": true,
+          "isSigner": true,
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "value",
+          "type": "u64"
+        },
+        {
+          "name": "key",
+          "type": "publicKey"
+        },
+        {
+          "name": "pdaBump",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "realloc",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "optional": true
+        },
+        {
+          "name": "optionalPda",
+          "isMut": true,
+          "isSigner": false,
+          "optional": true
+        },
+        {
+          "name": "required",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "optional": true
+        },
+        {
+          "name": "optionalAccount",
+          "isMut": true,
+          "isSigner": true,
+          "optional": true
+        }
+      ],
+      "args": [
+        {
+          "name": "newSize",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "close",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "optional": true
+        },
+        {
+          "name": "optionalPda",
+          "isMut": true,
+          "isSigner": false,
+          "optional": true
+        },
+        {
+          "name": "dataAccount",
+          "isMut": true,
+          "isSigner": true,
+          "optional": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false,
+          "optional": true
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "DataPda",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "dataAccount",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DataAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": "u64"
+          }
+        ]
+      }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "ReallocFailed",
+      "msg": "Failed realloc"
+    }
+  ],
+  "metadata": {
+    "address": "FNqz6pqLAwvMSds2FYjR4nKV3moVpPNtvkfGFrqLKrgG"
+  }
+}

--- a/test/integration/fixtures/feat-optional-accounts.json
+++ b/test/integration/fixtures/feat-optional-accounts.json
@@ -1,0 +1,68 @@
+{
+  "version": "",
+  "name": "",
+  "instructions": [
+    {
+      "name": "CreateThingWithOptional",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "thing",
+          "isMut": true,
+          "isSigner": false,
+          "optional": true
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    },
+    {
+      "name": "CreateThingWithOptionalDefaulting",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "thing",
+          "isMut": true,
+          "isSigner": false,
+          "optional": true
+        }
+      ],
+      "args": [],
+      "defaultOptionalAccounts": true,
+      "discriminant": {
+        "type": "u8",
+        "value": 0
+      }
+    },
+    {
+      "name": "CloseThing",
+      "accounts": [
+        {
+          "name": "creator",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [],
+      "discriminant": {
+        "type": "u8",
+        "value": 1
+      }
+    }
+  ],
+  "metadata": {
+    "origin": "shank",
+    "address": "A1BvUFMKzoubnHEFhvhJxXyTfEN6r2DqCZxJFF9hfH3x"
+  }
+}

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -235,6 +235,51 @@ test('ix: three accounts, two optional', async (t) => {
   })
 })
 
+test('ix: three accounts, two optional, defaultOptionalsToProgramId', async (t) => {
+  const ix = <IdlInstruction>{
+    name: 'choicy',
+    defaultOptionalsToProgramId: true,
+    accounts: [
+      {
+        name: 'authority',
+        isMut: false,
+        isSigner: true,
+      },
+      {
+        name: 'useAuthorityRecord',
+        isMut: true,
+        isSigner: false,
+        desc: 'Use Authority Record PDA If present the program Assumes a delegated use authority',
+        optional: true,
+      },
+      {
+        name: 'burner',
+        isMut: false,
+        isSigner: false,
+        desc: 'Program As Signer (Burner)',
+        optional: true,
+      },
+    ],
+    args: [],
+  }
+  await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
+    rxs: [
+      // Ensuring that the pubkeys for optional accounts aren't required
+      /authority\: web3\.PublicKey/,
+      /useAuthorityRecord\?\: web3\.PublicKey/,
+      /burner\?\: web3\.PublicKey/,
+      // Ensuring that the keys and mut/signer is set correctly
+      /pubkey\: accounts\.useAuthorityRecord \?\? programId,.+isWritable\: !!accounts\.useAuthorityRecord,.+isSigner\: false/,
+      /pubkey\: accounts\.burner \?\? programId,.+isWritable\: false,.+isSigner\: false/,
+    ],
+    nonrxs: [
+      /if \(accounts.useAuthorityRecord != null\)/,
+      /if \(accounts.burner != null\)/,
+      /if \(accounts.useAuthorityRecord == null\).+throw new Error/,
+    ]
+  })
+})
+
 test('ix: accounts render comments with and without desc', async (t) => {
   const ix = <IdlInstruction>{
     name: 'choicy',

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -271,7 +271,7 @@ test('ix: three accounts, two optional, defaultOptionalsToProgramId', async (t) 
       /useAuthorityRecord\?\: web3\.PublicKey/,
       /burner\?\: web3\.PublicKey/,
       // Ensuring that the keys and mut/signer is set correctly
-      /pubkey\: accounts\.useAuthorityRecord \?\? programId,\n.+isWritable\: !!accounts\.useAuthorityRecord,\n.+isSigner\: false,/,
+      /pubkey\: accounts\.useAuthorityRecord \?\? programId,\n.+isWritable\: accounts\.useAuthorityRecord \?\? false,\n.+isSigner\: false,/,
       /pubkey\: accounts\.burner \?\? programId,\n.+isWritable\: false,\n.+isSigner\: false,/,
     ],
     nonrxs: [

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -263,14 +263,16 @@ test('ix: three accounts, two optional, defaultOptionalsToProgramId', async (t) 
     args: [],
   }
   await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
+    logCode: true,
+    verify: true,
     rxs: [
       // Ensuring that the pubkeys for optional accounts aren't required
       /authority\: web3\.PublicKey/,
       /useAuthorityRecord\?\: web3\.PublicKey/,
       /burner\?\: web3\.PublicKey/,
       // Ensuring that the keys and mut/signer is set correctly
-      /pubkey\: accounts\.useAuthorityRecord \?\? programId,.+isWritable\: !!accounts\.useAuthorityRecord,.+isSigner\: false/,
-      /pubkey\: accounts\.burner \?\? programId,.+isWritable\: false,.+isSigner\: false/,
+      /pubkey\: accounts\.useAuthorityRecord \?\? programId,\n.+isWritable\: !!accounts\.useAuthorityRecord,\n.+isSigner\: false,/,
+      /pubkey\: accounts\.burner \?\? programId,\n.+isWritable\: false,\n.+isSigner\: false,/,
     ],
     nonrxs: [
       /if \(accounts.useAuthorityRecord != null\)/,

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -235,10 +235,10 @@ test('ix: three accounts, two optional', async (t) => {
   })
 })
 
-test('ix: three accounts, two optional, defaultOptionalsToProgramId', async (t) => {
+test.only('ix: three accounts, two optional, defaultOptionalAccounts', async (t) => {
   const ix = <IdlInstruction>{
     name: 'choicy',
-    defaultOptionalsToProgramId: true,
+    defaultOptionalAccounts: true,
     accounts: [
       {
         name: 'authority',
@@ -278,7 +278,7 @@ test('ix: three accounts, two optional, defaultOptionalsToProgramId', async (t) 
       /if \(accounts.useAuthorityRecord != null\)/,
       /if \(accounts.burner != null\)/,
       /if \(accounts.useAuthorityRecord == null\).+throw new Error/,
-    ]
+    ],
   })
 })
 

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -232,10 +232,14 @@ test('ix: three accounts, two optional', async (t) => {
       // provided, but not only the second optional pubkey
       /if \(accounts.useAuthorityRecord == null\).+throw new Error/,
     ],
+    nonrxs: [
+      /pubkey\: accounts\.useAuthorityRecord \?\? programId,\n.+isWritable\: accounts\.useAuthorityRecord != null,\n.+isSigner\: false,/,
+      /pubkey\: accounts\.burner \?\? programId,\n.+isWritable\: false,\n.+isSigner\: false,/,
+    ],
   })
 })
 
-test.only('ix: three accounts, two optional, defaultOptionalAccounts', async (t) => {
+test('ix: three accounts, two optional, defaultOptionalAccounts', async (t) => {
   const ix = <IdlInstruction>{
     name: 'choicy',
     defaultOptionalAccounts: true,
@@ -263,15 +267,13 @@ test.only('ix: three accounts, two optional, defaultOptionalAccounts', async (t)
     args: [],
   }
   await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
-    logCode: true,
-    verify: true,
     rxs: [
       // Ensuring that the pubkeys for optional accounts aren't required
       /authority\: web3\.PublicKey/,
       /useAuthorityRecord\?\: web3\.PublicKey/,
       /burner\?\: web3\.PublicKey/,
       // Ensuring that the keys and mut/signer is set correctly
-      /pubkey\: accounts\.useAuthorityRecord \?\? programId,\n.+isWritable\: accounts\.useAuthorityRecord \?\? false,\n.+isSigner\: false,/,
+      /pubkey\: accounts\.useAuthorityRecord \?\? programId,\n.+isWritable\: accounts\.useAuthorityRecord != null,\n.+isSigner\: false,/,
       /pubkey\: accounts\.burner \?\? programId,\n.+isWritable\: false,\n.+isSigner\: false,/,
     ],
     nonrxs: [


### PR DESCRIPTION
This PR adds support for "Anchor-style" optional accounts. The addition to the `IdlInstruction` type is a placeholder for now. 