### PR TITLE
Allow required accounts after optional accounts when rendering instruction keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 yarn.lock
 test/integration/output
 .crates/
+node_modules

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -217,47 +217,46 @@ ${typeMapperImports.join('\n')}`.trim()
       return ''
     }
 
-    const statements =
-      processedKeys
-        .map((processedKey, idx) => {
-          if (!processedKey.optional) {
-            const accountMeta = renderRequiredAccountMeta(
-              processedKey,
-              this.programIdPubkey
-            )
-            return `keys.push(${accountMeta})`
-          }
-
-          const requiredOptionals = processedKeys
-            .slice(0, idx)
-            .filter((x) => x.optional)
-          const requiredChecks = requiredOptionals
-            .map((x) => `accounts.${x.name} == null`)
-            .join(' || ')
-          const checkRequireds =
-            requiredChecks.length > 0
-              ? `if (${requiredChecks}) { throw new Error('When providing \\'${processedKey.name}\\' then ` +
-                `${requiredOptionals
-                  .map((x) => `\\'accounts.${x.name}\\'`)
-                  .join(', ')} need(s) to be provided as well.') }`
-              : ''
-          const pubkey = `accounts.${processedKey.name}`
-          const accountMeta = renderAccountMeta(
-            pubkey,
-            processedKey.isMut.toString(),
-            processedKey.isSigner.toString()
+    const statements = processedKeys
+      .map((processedKey, idx) => {
+        if (!processedKey.optional) {
+          const accountMeta = renderRequiredAccountMeta(
+            processedKey,
+            this.programIdPubkey
           )
+          return `keys.push(${accountMeta})`
+        }
 
-          // renderRequiredAccountMeta
-          // NOTE: we purposely don't add the default resolution here since the intent is to
-          // only pass that account when it is provided
-          return `
+        const requiredOptionals = processedKeys
+          .slice(0, idx)
+          .filter((x) => x.optional)
+        const requiredChecks = requiredOptionals
+          .map((x) => `accounts.${x.name} == null`)
+          .join(' || ')
+        const checkRequireds =
+          requiredChecks.length > 0
+            ? `if (${requiredChecks}) { throw new Error('When providing \\'${processedKey.name}\\' then ` +
+              `${requiredOptionals
+                .map((x) => `\\'accounts.${x.name}\\'`)
+                .join(', ')} need(s) to be provided as well.') }`
+            : ''
+        const pubkey = `accounts.${processedKey.name}`
+        const accountMeta = renderAccountMeta(
+          pubkey,
+          processedKey.isMut.toString(),
+          processedKey.isSigner.toString()
+        )
+
+        // renderRequiredAccountMeta
+        // NOTE: we purposely don't add the default resolution here since the intent is to
+        // only pass that account when it is provided
+        return `
 if (accounts.${processedKey.name} != null) {
   ${checkRequireds}
   keys.push(${accountMeta})
 }`.trim()
-        })
-        .join('\n')
+      })
+      .join('\n')
 
     return `\n${statements}\n`
   }

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -11,7 +11,6 @@ import {
   PrimitiveTypeKey,
   isAccountsCollection,
 } from './types'
-import { strict as assert } from 'assert'
 import { ForceFixable, TypeMapper } from './type-mapper'
 import { renderDataStruct } from './serdes'
 import {
@@ -189,59 +188,78 @@ ${typeMapperImports.join('\n')}`.trim()
   private renderAccountKeysNotDefaultingOptionals(
     processedKeys: ProcessedAccountKey[]
   ) {
-    const requireds = processedKeys.filter((x) => !x.optional)
-    const optionals = processedKeys.filter((x, idx) => {
-      if (!x.optional) return false
-      assert(
-        idx >= requireds.length,
-        `All optional accounts need to follow required accounts, ${x.name} is not`
-      )
-      return true
-    })
+    const indexOfFirstOptional = processedKeys.findIndex((x) => x.optional)
+    if (indexOfFirstOptional === -1) {
+      return this.renderAccountKeysInsideArray(processedKeys) + '\n'
+    }
 
-    const requiredKeys = this.renderAccountKeysRequired(requireds)
-    const optionalKeys =
-      optionals.length > 0
-        ? optionals
-            .map(({ name, isMut, isSigner }, idx) => {
-              const requiredOptionals = optionals.slice(0, idx)
-              const requiredChecks = requiredOptionals
-                .map((x) => `accounts.${x.name} == null`)
-                .join(' || ')
-              const checkRequireds =
-                requiredChecks.length > 0
-                  ? `if (${requiredChecks}) { throw new Error('When providing \\'${name}\\' then ` +
-                    `${requiredOptionals
-                      .map((x) => `\\'accounts.${x.name}\\'`)
-                      .join(', ')} need(s) to be provided as well.') }`
-                  : ''
-              const pubkey = `accounts.${name}`
-              const accountMeta = renderAccountMeta(
-                pubkey,
-                isMut.toString(),
-                isSigner.toString()
-              )
-              // NOTE: we purposely don't add the default resolution here since the intent is to
-              // only pass that account when it is provided
-              return `
-  if (accounts.${name} != null) {
-    ${checkRequireds}
-    keys.push(${accountMeta})
-  }`
-            })
-            .join('\n') + '\n'
-        : ''
+    const accountsInsideArray = this.renderAccountKeysInsideArray(
+      processedKeys.slice(0, indexOfFirstOptional)
+    )
+    const accountsToPush = this.renderAccountKeysToPush(
+      processedKeys.slice(indexOfFirstOptional)
+    )
 
-    return `${requiredKeys}\n${optionalKeys}`
+    return `${accountsInsideArray}\n${accountsToPush}`
   }
 
-  private renderAccountKeysRequired(processedKeys: ProcessedAccountKey[]) {
+  private renderAccountKeysInsideArray(processedKeys: ProcessedAccountKey[]) {
     const metaElements = processedKeys
       .map((processedKey) =>
         renderRequiredAccountMeta(processedKey, this.programIdPubkey)
       )
       .join(',\n    ')
     return `[\n    ${metaElements}\n  ]`
+  }
+
+  private renderAccountKeysToPush(processedKeys: ProcessedAccountKey[]) {
+    if (processedKeys.length === 0) {
+      return ''
+    }
+
+    const statements =
+      processedKeys
+        .map((processedKey, idx) => {
+          if (!processedKey.optional) {
+            const accountMeta = renderRequiredAccountMeta(
+              processedKey,
+              this.programIdPubkey
+            )
+            return `keys.push(${accountMeta})`
+          }
+
+          const requiredOptionals = processedKeys
+            .slice(0, idx)
+            .filter((x) => x.optional)
+          const requiredChecks = requiredOptionals
+            .map((x) => `accounts.${x.name} == null`)
+            .join(' || ')
+          const checkRequireds =
+            requiredChecks.length > 0
+              ? `if (${requiredChecks}) { throw new Error('When providing \\'${processedKey.name}\\' then ` +
+                `${requiredOptionals
+                  .map((x) => `\\'accounts.${x.name}\\'`)
+                  .join(', ')} need(s) to be provided as well.') }`
+              : ''
+          const pubkey = `accounts.${processedKey.name}`
+          const accountMeta = renderAccountMeta(
+            pubkey,
+            processedKey.isMut.toString(),
+            processedKey.isSigner.toString()
+          )
+
+          // renderRequiredAccountMeta
+          // NOTE: we purposely don't add the default resolution here since the intent is to
+          // only pass that account when it is provided
+          return `
+if (accounts.${processedKey.name} != null) {
+  ${checkRequireds}
+  keys.push(${accountMeta})
+}`
+        })
+        .join('\n') + '\n'
+
+    return `\n${statements}\n`
   }
 
   // -----------------

--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -255,9 +255,9 @@ ${typeMapperImports.join('\n')}`.trim()
 if (accounts.${processedKey.name} != null) {
   ${checkRequireds}
   keys.push(${accountMeta})
-}`
+}`.trim()
         })
-        .join('\n') + '\n'
+        .join('\n')
 
     return `\n${statements}\n`
   }

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -239,6 +239,63 @@ test('ix: three accounts, two optional', async (t) => {
   })
 })
 
+test('ix: five accounts composed of two required, two optional and one required', async (t) => {
+  const ix = <IdlInstruction>{
+    name: 'sandwichedOptionalAccounts',
+    accounts: [
+      {
+        name: 'authority',
+        isMut: false,
+        isSigner: true,
+      },
+      {
+        name: 'metadata',
+        isMut: true,
+        isSigner: false,
+      },
+      {
+        name: 'useAuthorityRecord',
+        isMut: true,
+        isSigner: false,
+        desc: 'Use Authority Record PDA If present the program Assumes a delegated use authority',
+        optional: true,
+      },
+      {
+        name: 'burner',
+        isMut: false,
+        isSigner: false,
+        desc: 'Program As Signer (Burner)',
+        optional: true,
+      },
+      {
+        name: 'masterEdition',
+        isMut: false,
+        isSigner: false,
+      },
+    ],
+    args: [],
+  }
+  await checkRenderedIx(t, ix, [BEET_PACKAGE, SOLANA_WEB3_PACKAGE], {
+    rxs: [
+      // Ensuring that the pubkeys for optional accounts aren't required
+      /authority\: web3\.PublicKey/,
+      /metadata\: web3\.PublicKey/,
+      /useAuthorityRecord\?\: web3\.PublicKey/,
+      /burner\?\: web3\.PublicKey/,
+      /masterEdition\: web3\.PublicKey/,
+      // Ensuring we are pushing the last 3 accounts.
+      /keys\.push\(\{\s+pubkey\: accounts\.useAuthorityRecord,/,
+      /keys\.push\(\{\s+pubkey\: accounts\.burner,/,
+      /keys\.push\(\{\s+pubkey\: accounts\.masterEdition,/,
+    ],
+    nonrxs: [
+      // Ensuring we are not pushing the first 2 accounts.
+      /keys\.push\(\{\s+pubkey\: accounts\.authority,/,
+      /keys\.push\(\{\s+pubkey\: accounts\.metadata,/,
+    ]
+  })
+})
+
 test('ix: three accounts, two optional, defaultOptionalAccounts', async (t) => {
   const ix = <IdlInstruction>{
     name: 'choicy',


### PR DESCRIPTION
The current behaviour, when rendering the AccountMetas of an instruction, is to render all required accounts first and then the optional ones if any. If any required accounts are added after optional accounts, Solita will throw an error and fail to generate a library.

The issue with this approach is that some instructions may want to add required accounts after optional accounts to minimize breaking changes which is currently the case for one instruction of the Token Metadata program.

This PR solves this by allowing required accounts to be pushed to the `keys` array after optional accounts if any. The logic is as follows:
- It will first render the account array using all required accounts that appear before the first optional one.
- Then for every account after that, it will push that account using `keys.push({...})`. If it's an optional account, it will wrap this push statement in an if statement as expected.