### PR TITLE
Fix dataEnum cast

### DIFF
--- a/src/render-data-enum.ts
+++ b/src/render-data-enum.ts
@@ -41,7 +41,7 @@ export function renderTypeDataEnumBeet(args: {
 
   return `export const ${beetVarName} = ${BEET_EXPORT_NAME}.dataEnum<${enumRecordName}>([
   ${renderedBeets} 
-]) as ${BEET_EXPORT_NAME}.${beetType}<${typeName}>
+]) as ${BEET_EXPORT_NAME}.${beetType}<${typeName}, ${typeName}>
 `
 }
 


### PR DESCRIPTION
This PR aims to make the type of generated `dataEnum` slightly stricter by providing the second type parameter of `Beet<T, V>`.

When type `V` is missing, it defaults to `Partial<T>` which makes little sense in the case of a `dataEnum` since we've got to provide the `__kind` in order to know how to serialise it.

This causes issues when using `dataEnum` types in other types such as the `map` type which expect both its keys and values to be of type `Beet<K, K>` and `Beet<V, V>` respectively.

Here's an example.

## Before

```ts
export const payloadTypeBeet = beet.dataEnum<PayloadTypeRecord>([
  // ...
]) as beet.FixableBeet<PayloadType>;
```

When used in a map type, it throws a TypeError.

```ts
export const payloadBeet = new beet.FixableBeetArgsStruct<Payload>(
  [['map', beet.map(payloadKeyBeet, payloadTypeBeet)]],
                                 // ^-------------- TypeError: '__kind' is optional in type Partial<...>
  'Payload',
);
```

## After

```ts
export const payloadTypeBeet = beet.dataEnum<PayloadTypeRecord>([
  // ...
]) as beet.FixableBeet<PayloadType, PayloadType>;
```

Now the following type works.

```ts
export const payloadBeet = new beet.FixableBeetArgsStruct<Payload>(
  [['map', beet.map(payloadKeyBeet, payloadTypeBeet)]],
  'Payload',
);