### PR TITLE
Add support for isOptional instruction account attribute

### DIFF
--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -125,7 +125,7 @@ ${typeMapperImports.join('\n')}`.trim()
           // Make collection items easy to identify and avoid name clashes
           ac.name = deriveCollectionAccountsName(ac.name, acc.name)
           const knownPubkey = resolveKnownPubkey(ac.name)
-          const optional = ac.optional ?? false
+          const optional = ac.optional ?? ac.isOptional ?? false
           if (knownPubkey == null) {
             processedAccountsKey.push({ ...ac, optional })
           } else {
@@ -134,7 +134,7 @@ ${typeMapperImports.join('\n')}`.trim()
         }
       } else {
         const knownPubkey = resolveKnownPubkey(acc.name)
-        const optional = acc.optional ?? false
+        const optional = acc.optional ?? acc.isOptional ?? false
         if (knownPubkey == null) {
           processedAccountsKey.push({ ...acc, optional })
         } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -450,7 +450,7 @@ export const BIGNUM = [
   'i256',
   'i512',
 ] as const
-export type Bignum = typeof BIGNUM[number]
+export type Bignum = (typeof BIGNUM)[number]
 export function isNumberLikeType(ty: IdlType): ty is NumbersTypeMapKey {
   return (
     typeof ty === 'string' && numbersTypeMap[ty as NumbersTypeMapKey] != null

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export type IdlInstructionAccount = {
   isSigner: boolean
   desc?: string
   optional?: boolean
+  isOptional?: boolean
 }
 
 export type IdlType =


### PR DESCRIPTION
## Problem

Anchor labels optional instruction accounts using the `isOptional` attribute whereas Solita expects the `optional` attribute as Shank uses the latter.

## Solution

Support both `optional` and `isOptional` attributes to label optional instruction accounts.