### PR TITLE
Default optional account strategy to program ID

### DIFF
--- a/src/render-instruction.ts
+++ b/src/render-instruction.ts
@@ -65,7 +65,7 @@ class InstructionRenderer {
       typeMapper
     )
     this.programIdPubkey = `new ${SOLANA_WEB3_EXPORT_NAME}.PublicKey('${this.programId}')`
-    this.defaultOptionalAccounts = ix.defaultOptionalAccounts ?? false
+    this.defaultOptionalAccounts = !ix.legacyOptionalAccountsStrategy
   }
 
   // -----------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,7 @@ export type IdlInstructionArg = {
 export type IdlInstruction = {
   name: string
   defaultOptionalAccounts?: boolean
+  legacyOptionalAccountsStrategy?: boolean
   accounts: IdlInstructionAccount[] | IdlAccountsCollection[]
   args: IdlInstructionArg[]
 }

--- a/test/render-instruction.ts
+++ b/test/render-instruction.ts
@@ -195,6 +195,7 @@ test('ix: two accounts and two args', async (t) => {
 test('ix: three accounts, two optional', async (t) => {
   const ix = <IdlInstruction>{
     name: 'choicy',
+    legacyOptionalAccountsStrategy: true,
     accounts: [
       {
         name: 'authority',
@@ -242,6 +243,7 @@ test('ix: three accounts, two optional', async (t) => {
 test('ix: five accounts composed of two required, two optional and one required', async (t) => {
   const ix = <IdlInstruction>{
     name: 'sandwichedOptionalAccounts',
+    legacyOptionalAccountsStrategy: true,
     accounts: [
       {
         name: 'authority',
@@ -292,14 +294,13 @@ test('ix: five accounts composed of two required, two optional and one required'
       // Ensuring we are not pushing the first 2 accounts.
       /keys\.push\(\{\s+pubkey\: accounts\.authority,/,
       /keys\.push\(\{\s+pubkey\: accounts\.metadata,/,
-    ]
+    ],
   })
 })
 
 test('ix: three accounts, two optional, defaultOptionalAccounts', async (t) => {
   const ix = <IdlInstruction>{
     name: 'choicy',
-    defaultOptionalAccounts: true,
     accounts: [
       {
         name: 'authority',
@@ -431,6 +432,7 @@ test('ix: with args one system program account and programId', async (t) => {
 test('ix: empty args one system program account + one optional rent account', async (t) => {
   const ix = {
     name: 'empyArgsWithSystemProgram',
+    legacyOptionalAccountsStrategy: true,
     accounts: [
       {
         name: 'authority',


### PR DESCRIPTION
As the new shank version will assume.

This is a breaking change so the library should be bumped accordingly.