### PR TITLE
Add binaryArgs field

### DIFF
--- a/src/cli/handlers.ts
+++ b/src/cli/handlers.ts
@@ -26,7 +26,8 @@ export function handleAnchor(
   prettierConfig?: PrettierOptions
 ) {
   const { idlDir, binaryInstallDir, programDir } = config
-  const spawnArgs = ['build', '--idl', idlDir]
+  const binaryArgs = config.binaryArgs?.split(' ') ?? []
+  const spawnArgs = ['build', '--idl', idlDir, ...binaryArgs]
   const spawnOpts: SpawnOptionsWithoutStdio = {
     cwd: programDir,
   }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -13,6 +13,7 @@ export type SolitaConfigBase = {
   typeAliases?: TypeAliases
   serializers?: Serializers
   removeExistingIdl?: boolean
+  binaryArgs?: string
 }
 
 export type SolitaConfigAnchor = SolitaConfigBase & {

--- a/test/anchor-examples/basic-0/.solitarc.js
+++ b/test/anchor-examples/basic-0/.solitarc.js
@@ -13,4 +13,5 @@ module.exports = {
   sdkDir,
   binaryInstallDir,
   programDir,
+  binaryArgs: "-- --features testing"
 }

--- a/test/anchor-examples/basic-0/idl/basic_0.json
+++ b/test/anchor-examples/basic-0/idl/basic_0.json
@@ -11,7 +11,7 @@
   "metadata": {
     "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
     "origin": "anchor",
-    "binaryVersion": "0.24.2",
-    "libVersion": "0.24.2"
+    "binaryVersion": "0.27.0",
+    "libVersion": "0.27.0"
   }
 }

--- a/test/anchor-examples/basic-0/programs/basic-0/Cargo.toml
+++ b/test/anchor-examples/basic-0/programs/basic-0/Cargo.toml
@@ -11,6 +11,7 @@ name = "basic_0"
 [features]
 no-entrypoint = []
 cpi = ["no-entrypoint"]
+testing = []
 
 [dependencies]
-anchor-lang = "0.24.2"
+anchor-lang = "0.27.0"

--- a/test/anchor-examples/basic-1/idl/basic_1.json
+++ b/test/anchor-examples/basic-1/idl/basic_1.json
@@ -62,7 +62,7 @@
   "metadata": {
     "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
     "origin": "anchor",
-    "binaryVersion": "0.24.2",
-    "libVersion": "0.24.2"
+    "binaryVersion": "0.27.0",
+    "libVersion": "0.27.0"
   }
 }

--- a/test/anchor-examples/basic-1/programs/basic-1/Cargo.toml
+++ b/test/anchor-examples/basic-1/programs/basic-1/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = "0.24.2"
+anchor-lang = "0.27.0"

--- a/test/anchor-examples/basic-2/idl/basic_2.json
+++ b/test/anchor-examples/basic-2/idl/basic_2.json
@@ -66,7 +66,7 @@
   "metadata": {
     "address": "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
     "origin": "anchor",
-    "binaryVersion": "0.24.2",
-    "libVersion": "0.24.2"
+    "binaryVersion": "0.27.0",
+    "libVersion": "0.27.0"
   }
 }

--- a/test/anchor-examples/basic-2/programs/basic-2/Cargo.toml
+++ b/test/anchor-examples/basic-2/programs/basic-2/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = "0.24.2"
+anchor-lang = "0.27.0"

--- a/test/anchor-examples/basic-3/programs/puppet-master/Cargo.toml
+++ b/test/anchor-examples/basic-3/programs/puppet-master/Cargo.toml
@@ -13,5 +13,5 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = "0.24.2"
+anchor-lang = "0.27.0"
 puppet = { path = "../puppet", features = ["cpi"] }

--- a/test/anchor-examples/basic-3/programs/puppet/Cargo.toml
+++ b/test/anchor-examples/basic-3/programs/puppet/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = "0.24.2"
+anchor-lang = "0.27.0"

--- a/test/anchor-examples/basic-4/idl/basic_4.json
+++ b/test/anchor-examples/basic-4/idl/basic_4.json
@@ -99,7 +99,7 @@
   "metadata": {
     "address": "CwrqeMj2U8tFr1Rhkgwc84tpAsqbt9pTt2a4taoTADPr",
     "origin": "anchor",
-    "binaryVersion": "0.24.2",
-    "libVersion": "0.24.2"
+    "binaryVersion": "0.27.0",
+    "libVersion": "0.27.0"
   }
 }

--- a/test/anchor-examples/basic-4/programs/basic-4/Cargo.toml
+++ b/test/anchor-examples/basic-4/programs/basic-4/Cargo.toml
@@ -13,4 +13,4 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = "0.24.2"
+anchor-lang = "0.27.0"


### PR DESCRIPTION
This PR adds a `binaryArgs` property to `SolitaConfigBase` to allow configuring command-line arguments for the IDL generator.